### PR TITLE
Add compiler runtime option to build specoial K4A SDK for MTE use

### DIFF
--- a/src/depth/CMakeLists.txt
+++ b/src/depth/CMakeLists.txt
@@ -1,13 +1,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-if (K4A_MTE_VERSION)
-  add_definitions(-DK4A_MTE_VERSION)
-endif ()
-
 add_library(k4a_depth STATIC 
             depth.c
             )
+
+if (K4A_MTE_VERSION)
+    target_compile_definitions(k4a_depth PRIVATE K4A_MTE_VERSION)
+endif ()
 
 # Consumers should #include <k4ainternal/depth.h>
 target_include_directories(k4a_depth PUBLIC 


### PR DESCRIPTION
Compile with following option to build the SDK for MTE use
cmake **-DK4A_MTE_VERSION=ON** -GNinja ..
Ninja

Tested on my device by manually increasing the FW version number to a higher value and run depth_ft without reporting error.