### PR TITLE
Remove imported lib from libyuv

### DIFF
--- a/extern/libyuv/CMakeLists.txt
+++ b/extern/libyuv/CMakeLists.txt
@@ -3,7 +3,10 @@ if (NOT TARGET yuv)
         add_compile_options("/D_CRT_SECURE_NO_WARNINGS")
     endif()
 
+    set(CMAKE_IMPORT_LIBRARY_SUFFIX_CACHED ${CMAKE_IMPORT_LIBRARY_SUFFIX})
+    unset(CMAKE_IMPORT_LIBRARY_SUFFIX)
     add_subdirectory(src EXCLUDE_FROM_ALL)
+    set(CMAKE_IMPORT_LIBRARY_SUFFIX ${CMAKE_IMPORT_LIBRARY_SUFFIX_CACHED})
 
     target_include_directories(yuv PUBLIC
         src


### PR DESCRIPTION
In libyuv the imported lib for the DLL has the same name as the static
lib. Thus, there is a target conflict that the lastest version of ninja
will complain about.

This works around this issue by tricking cmake into not generating a
import lib for libyuv as we use the static lib only.