### PR TITLE
K4AViewer: Adjust playback timestamps based on recording metadata

### DIFF
--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -44,11 +44,19 @@ template<typename output_type, typename input_type> output_type clamp_cast(input
 {
     static_assert(std::is_arithmetic<input_type>::value, "clamp_cast only supports arithmetic types");
     static_assert(std::is_arithmetic<output_type>::value, "clamp_cast only supports arithmetic types");
-    const input_type minValue = std::is_signed<input_type>() ?
-                                    static_cast<input_type>(std::numeric_limits<output_type>::min()) :
-                                    0;
-    input = std::min(input, static_cast<input_type>(std::numeric_limits<output_type>::max()));
-    input = std::max(input, minValue);
+    const input_type min_value = std::is_signed<input_type>() ?
+                                     static_cast<input_type>(std::numeric_limits<output_type>::min()) :
+                                     0;
+
+    input_type max_value = static_cast<input_type>(std::numeric_limits<output_type>::max());
+    if (max_value < 0)
+    {
+        // Output type is of greater or equal size to input type and we've overflowed.
+        //
+        max_value = std::numeric_limits<input_type>::max();
+    }
+    input = std::min(input, max_value);
+    input = std::max(input, min_value);
     return static_cast<output_type>(input);
 }
 /// @endcond

--- a/tools/k4aviewer/k4arecordingdockcontrol.h
+++ b/tools/k4aviewer/k4arecordingdockcontrol.h
@@ -35,6 +35,7 @@ private:
 
     void ReadNext();
     void Step(bool backward);
+    void SetCurrentCapture(k4a::capture &&capture);
 
     std::unique_ptr<K4ARecordingDockControl> m_dockControl;
 

--- a/tools/k4aviewer/perfcounter.h
+++ b/tools/k4aviewer/perfcounter.h
@@ -10,6 +10,7 @@
 #include <array>
 #include <chrono>
 #include <map>
+#include <mutex>
 #include <numeric>
 #include <ratio>
 
@@ -35,7 +36,9 @@ public:
     static void ShowPerfWindow(bool *windowOpen);
 
 private:
-    static std::map<std::string, PerfCounter *> m_perfCounters;
+    static PerfCounterManager &Instance();
+    std::map<std::string, PerfCounter *> m_perfCounters;
+    std::mutex m_mutex;
 };
 
 // A wrapper for taking a single perf measurement.  Timing starts when the sample is created.


### PR DESCRIPTION
K4A recordings have an embedded timestamp offset that indicates how far off the master the timestamps in the recording are.  Adding this to the timestamps on the images in the recording lets you correlate timestamps between multiple synchronized recordings.

Previously, we weren't doing that addition automatically, which made it awkward to step through synchronized recordings in K4AViewer; this makes the viewer show the adjusted timestamps instead.

Also fix a couple bugs:
- The C++ wrapper version of set_timestamp and set_exposure_time didn't work on systems where the representation for std::chrono::microseconds was int64_t due to an overflow when casting uint64_t::max to int64_t
- There was a race condition in performance counter initialization that sometimes resulted in a segfault when registering the perf counter because the std::map containing the list of perf counters was being used before it was constructed (timing issue, seems to only happen when broken into the debugger)