### PR TITLE
Revert "Enable color functional tests on Linux"

### DIFF
--- a/tests/ColorTests/FunctionalTest/CMakeLists.txt
+++ b/tests/ColorTests/FunctionalTest/CMakeLists.txt
@@ -9,4 +9,8 @@ target_link_libraries(color_ft PRIVATE
     gtest::gtest
     azure::aziotsharedutil)
 
-k4a_add_tests(TARGET color_ft HARDWARE_REQUIRED TEST_TYPE FUNCTIONAL)
+# Color functional tests do not currently work on Linux so we will not run
+# them.
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+    k4a_add_tests(TARGET color_ft HARDWARE_REQUIRED TEST_TYPE FUNCTIONAL)
+endif()


### PR DESCRIPTION
Reverts Microsoft/Azure-Kinect-Sensor-SDK#162