### PR TITLE
K4AViewer: point cloud bugfixes

### DIFF
--- a/tools/k4aviewer/gpudepthtopointcloudconverter.cpp
+++ b/tools/k4aviewer/gpudepthtopointcloudconverter.cpp
@@ -39,7 +39,17 @@ void main()
     float vertexValue = float(imageLoad(depthImage, pixel));
     vec2 xyValue = imageLoad(xyTable, pixel).xy;
 
+    float alpha = 1.0f;
     vec3 vertexPosition = vec3(vertexValue * xyValue.x, vertexValue * xyValue.y, vertexValue);
+
+    // Invalid pixels have their XY table values set to 0.
+    // Set the rest of their values to 0 so clients can pick them out.
+    //
+    if (xyValue.x == 0.0f && xyValue.y == 0.0f)
+    {
+        alpha = 0.0f;
+        vertexValue = 0.0f;
+    }
 
     // Vertex positions are in millimeters, but everything else is in meters, so we need to convert
     //
@@ -50,7 +60,7 @@ void main()
     //
     vertexPosition.x *= -1;
 
-    imageStore(destTex, pixel, vec4(vertexPosition, 1.0f));
+    imageStore(destTex, pixel, vec4(vertexPosition, alpha));
 }
 )";
 
@@ -250,8 +260,10 @@ k4a::image GpuDepthToPointCloudConverter::GenerateXyTable(const k4a::calibration
             }
             else
             {
-                tableData[idx].xy.x = FP_NAN;
-                tableData[idx].xy.y = FP_NAN;
+                // The pixel is invalid.
+                //
+                tableData[idx].xy.x = 0.0f;
+                tableData[idx].xy.y = 0.0f;
             }
         }
     }

--- a/tools/k4aviewer/k4apointcloudshaders.h
+++ b/tools/k4aviewer/k4apointcloudshaders.h
@@ -16,6 +16,11 @@ uniform bool enableShading;
 
 void main()
 {
+    if (fragmentColor.a == 0.0f)
+    {
+        discard;
+    }
+
     gl_FragColor = fragmentColor;
 }
 )";
@@ -58,6 +63,13 @@ void main()
     gl_Position = projection * view * vec4(vertexPosition, 1);
 
     fragmentColor = vertexColor;
+
+    // Pass along the 'invalid pixel' flag as the alpha channel
+    //
+    if (vertexPosition.z == 0.0f)
+    {
+        fragmentColor.a = 0.0f;
+    }
 
     if (enableShading)
     {


### PR DESCRIPTION
Fix two bugs in the point cloud viewer:
- A black pixel was being shown at (0, 0, 0) (all the depth pixels with no data got drawn here)
- Invalid pixels in the XY tables were not being handled correctly by the shaders, which caused a streaks of nonsense data in the color point cloud