### PR TITLE
K4AViewer: fix error message on unsynchronized captures

### DIFF
--- a/tools/k4aviewer/k4aimageextractor.h
+++ b/tools/k4aviewer/k4aimageextractor.h
@@ -26,7 +26,7 @@ public:
     template<k4a_image_format_t T> static k4a::image GetImageFromCapture(const k4a::capture &capture)
     {
         k4a::image img = capture.get_color_image();
-        if (img.get_format() != T)
+        if (!img || img.get_format() != T)
         {
             return k4a::image();
         }


### PR DESCRIPTION
When starting the cameras without synchronized_images_only set, we were sometimes trying to get the image format of null images, which raised an error in the log.  k4a_image_get_format returns K4A_IMAGE_FORMAT_CUSTOM in this case, which happened to never be what we were expecting to see, so the viewer dropped the image anyway, but with the addition of the new log pane, this became much more noticeable.

This adds a check to verify that the image is valid before trying to get its format, which prevents the error from being triggered.