### PR TITLE
K4AViewer: Point cloud viewer UI tweaks

### DIFF
--- a/tools/k4aviewer/k4apointcloudwindow.h
+++ b/tools/k4aviewer/k4apointcloudwindow.h
@@ -54,8 +54,6 @@ private:
     bool m_enableColorPointCloud = false;
 
     bool m_failed = false;
-    bool m_dragging = false;
-    bool m_dragStartedOnPointCloud = false;
 
     static constexpr int MaxConsecutiveMissingImages = 10;
     int m_consecutiveMissingImages = 0;


### PR DESCRIPTION
A couple minor fixes to the point cloud viewer UI:
- Only send rotation/translation events if the mouse drag started on the point cloud image itself (i.e. don't rotate the image if you drag the point size slider)
- Remove custom warning logging in favor of the new logging pane
- Only send zoom events if the point cloud window is hovered