### PR TITLE
K4AViewer: Only generate color xy tables on recordings with depth

### DIFF
--- a/tools/k4aviewer/k4apointcloudvisualizer.cpp
+++ b/tools/k4aviewer/k4apointcloudvisualizer.cpp
@@ -188,7 +188,11 @@ K4APointCloudVisualizer::K4APointCloudVisualizer(const bool enableColorPointClou
 
     m_viewControl.ResetPosition();
 
-    m_colorXyTable = m_pointCloudConverter.GenerateXyTable(m_calibrationData, K4A_CALIBRATION_TYPE_COLOR);
+    if (enableColorPointCloud)
+    {
+        m_colorXyTable = m_pointCloudConverter.GenerateXyTable(m_calibrationData, K4A_CALIBRATION_TYPE_COLOR);
+    }
+
     m_depthXyTable = m_pointCloudConverter.GenerateXyTable(m_calibrationData, K4A_CALIBRATION_TYPE_DEPTH);
 
     SetColorizationStrategy(m_colorizationStrategy);


### PR DESCRIPTION
The viewer was failing to show the point cloud view of depth-only recordings because we were failing to generate the XY tables for the color camera (depth-only recordings don't have enough information to create a color XY table).

Stop attempting to generate color XY tables for depth-only recordings.