### PR TITLE
Linux binaries search local path for shared objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,19 @@ if ("${K4A_ENABLE_LEAK_DETECTION_CMAKE}" STREQUAL "1")
     add_definitions(-DK4A_ENABLE_LEAK_DETECTION)
 endif()
 
+# Sets the RUNPATH entry in the .dynamic section of an elf. RUNPATH is
+# interpreted by the linux loader as an additional path to search for shared
+# objects. $ORIGIN is a special setting telling the loader to search the path
+# relative to the exectuable.
 #
-set(CMAKE_BUILD_WITH_INSTALL_RPATH YES)
-set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+# These specific settings tell the loader to search the directory of the
+# executable for shared objects. This is done on Linux to emulate the default
+# behavior of the Windows loader, which searches for DLLs in the path of the
+# executable.
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    set(CMAKE_BUILD_WITH_INSTALL_RPATH YES)
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+endif()
 
 add_subdirectory(examples)
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,10 @@ if ("${K4A_ENABLE_LEAK_DETECTION_CMAKE}" STREQUAL "1")
     add_definitions(-DK4A_ENABLE_LEAK_DETECTION)
 endif()
 
+#
+set(CMAKE_BUILD_WITH_INSTALL_RPATH YES)
+set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+
 add_subdirectory(examples)
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -588,7 +588,7 @@ jobs:
       displayName: 'Add execution property to findconnectedport'
 
     - task: CopyFiles@2
-      displayName: "Copy DepthEnginePlugin into LD_LIBRARY_PATH"
+      displayName: "Copy DepthEnginePlugin into Build Artifacts"
       inputs:
         sourceFolder: "$(System.ArtifactsDirectory)/depthengineplugin/linux/x86_64/release/"
         contents: "libdepthengine.so*"
@@ -598,11 +598,6 @@ jobs:
     - script: 'chmod +x ./x86_64-linux-clang-relwithdebinfo/bin/*'
       workingDirectory: '$(System.ArtifactsDirectory)'
       displayName: 'Add execution property to binary files'
-
-      # Adding the bin folder to the LD_LIBRARY_PATH, so the executables can find the necessary .so files.
-    - script: 'echo "##vso[task.setvariable variable=LD_LIBRARY_PATH]$BUILD_ARTIFACTSTAGINGDIRECTORY/x86_64-linux-clang-relwithdebinfo/bin/"'
-      workingDirectory: '$(System.ArtifactsDirectory)'
-      displayName: 'set LD_LIBRARY_PATH'
 
       # Set the DISPLAY variable since DepthEngine needs to open a display window (even there is no visual display).
     - script: 'echo "##vso[task.setvariable variable=DISPLAY]:0"'

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -62,14 +62,8 @@ add_library(k4a::k4a ALIAS k4a)
 set_target_properties(
     k4a
     PROPERTIES
-        VERSION
-	    ${K4A_VERSION}
-        SOVERSION
-	    ${K4A_VERSION}
-	INSTALL_RPATH
-	    "\$ORIGIN"
-	BUILD_WITH_INSTALL_RPATH
-	    YES)
+        VERSION ${K4A_VERSION}
+        SOVERSION ${K4A_VERSION})
 
 
 # Setup install

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -62,8 +62,14 @@ add_library(k4a::k4a ALIAS k4a)
 set_target_properties(
     k4a
     PROPERTIES
-        VERSION ${K4A_VERSION}
-        SOVERSION ${K4A_VERSION})
+        VERSION
+	    ${K4A_VERSION}
+        SOVERSION
+	    ${K4A_VERSION}
+	INSTALL_RPATH
+	    "\$ORIGIN"
+	BUILD_WITH_INSTALL_RPATH
+	    YES)
 
 
 # Setup install


### PR DESCRIPTION
## Fixes #310 

### Description of the changes:
- Changes all binaries to also search for local path for shared objects. This emulates the same behavior on Windows. The shared object search path on Linux is now (list taken from: https://amir.rachum.com/blog/2016/09/17/shared-libraries/#runtime-search-path)

1. Directories in the LD_LIBRARY_PATH environment variable, which contains colon-separated list of directories (e.g., /path/to/libdir:/another/path)
2. Directory of the executable or shared object doing the loading
3. The list of directories in the file /etc/ld.so.conf. This file can include other files, but it is basically a list of directories - one per line.
4. Default system libraries - usually /lib and /usr/lib (skipped if compiled with -z nodefaultlib).

This better lines up with the Windows DLL search path (https://docs.microsoft.com/en-us/windows/desktop/dlls/dynamic-link-library-search-order#search-order-for-desktop-applications)

1. The directory from which the application loaded.
2. The system directory. Use the GetSystemDirectory function to get the path of this directory.
The 16-bit system directory. There is no function that obtains the path of this directory, but it is searched.
3. The Windows directory. Use the GetWindowsDirectory function to get the path of this directory.
4. The current directory.
5. The directories that are listed in the PATH environment variable. Note that this does not include the per-application path specified by the App Paths registry key. The App Paths key is not used when computing the DLL search path.

### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on:
- [ ] Windows
- [x] Linux

I ran functional tests on Linux to ensure the depthengine binary was picked up.
