### PR TITLE
New API to query color camera control capabilities.

### DIFF
--- a/include/k4a/k4a.h
+++ b/include/k4a/k4a.h
@@ -1211,7 +1211,7 @@ K4A_EXPORT k4a_result_t k4a_device_get_version(k4a_device_t device_handle, k4a_h
  * \param command
  * Color sensor control command.
  *
- * \param support_auto
+ * \param supports_auto
  * Location to store whether the color sensor's control support auto mode or not.
  * true if it supports auto mode, otherwise false.
  *
@@ -1245,7 +1245,7 @@ K4A_EXPORT k4a_result_t k4a_device_get_version(k4a_device_t device_handle, k4a_h
  */
 K4A_EXPORT k4a_result_t k4a_device_get_color_control_capabilities(k4a_device_t device_handle,
                                                                   k4a_color_control_command_t command,
-                                                                  bool *support_auto,
+                                                                  bool *supports_auto,
                                                                   int32_t *min_value,
                                                                   int32_t *max_value,
                                                                   int32_t *step_value,

--- a/include/k4a/k4a.h
+++ b/include/k4a/k4a.h
@@ -1203,7 +1203,57 @@ K4A_EXPORT k4a_buffer_result_t k4a_device_get_serialnum(k4a_device_t device_hand
  */
 K4A_EXPORT k4a_result_t k4a_device_get_version(k4a_device_t device_handle, k4a_hardware_version_t *version);
 
-/** Get the Azure Kinect color sensor control value.
+/** Get the Azure Kinect color sensor control capabilities.
+ *
+ * \param device_handle
+ * Handle obtained by k4a_device_open().
+ *
+ * \param command
+ * Color sensor control command.
+ *
+ * \param support_auto
+ * Location to store whether the color sensor's control support auto mode or not.
+ * true if it supports auto mode, otherwise false.
+ *
+ * \param min_value
+ * Location to store the color sensor's control minimum value of /p command.
+ *
+ * \param max_value
+ * Location to store the color sensor's control maximum value of /p command.
+ *
+ * \param step_value
+ * Location to store the color sensor's control step value of /p command.
+ *
+ * \param default_value
+ * Location to store the color sensor's control default value of /p command.
+ *
+ * \param default_mode
+ * Location to store the color sensor's control default mode of /p command.
+ *
+ * \returns
+ * ::K4A_RESULT_SUCCEEDED if the value was successfully returned, ::K4A_RESULT_FAILED if an error occurred
+ *
+ * \relates k4a_device_t
+ *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4a.h (include k4a/k4a.h)</requirement>
+ *   <requirement name="Library">k4a.lib</requirement>
+ *   <requirement name="DLL">k4a.dll</requirement>
+ * </requirements>
+ * \endxmlonly
+ */
+K4A_EXPORT k4a_result_t k4a_device_get_color_control_capabilities(k4a_device_t device_handle,
+                                                                  k4a_color_control_command_t command,
+                                                                  bool *support_auto,
+                                                                  int32_t *min_value,
+                                                                  int32_t *max_value,
+                                                                  int32_t *step_value,
+                                                                  int32_t *default_value,
+                                                                  k4a_color_control_mode_t *default_mode);
+
+/** Get the Azure Kinect color sensor control
+ * value.
  *
  * \param device_handle
  * Handle obtained by k4a_device_open().
@@ -1212,27 +1262,27 @@ K4A_EXPORT k4a_result_t k4a_device_get_version(k4a_device_t device_handle, k4a_h
  * Color sensor control command.
  *
  * \param mode
- * Location to store the color sensor's control mode. This mode represents whether the command is in automatic or manual
- * mode.
+ * Location to store the color sensor's control mode. This mode represents whether the command is in automatic or
+ * manual mode.
  *
  * \param value
- * Location to store the color sensor's control value. This value is always written, but is only valid when the \p mode
- * returned is ::K4A_COLOR_CONTROL_MODE_MANUAL for the current \p command.
+ * Location to store the color sensor's control value. This value is always written, but is only valid when the \p
+ * mode returned is ::K4A_COLOR_CONTROL_MODE_MANUAL for the current \p command.
  *
  * \returns
  * ::K4A_RESULT_SUCCEEDED if the value was successfully returned, ::K4A_RESULT_FAILED if an error occurred
  *
  * \remarks
- * Each control command may be set to manual or automatic. See the definition of \ref k4a_color_control_command_t on how
- * to interpret the \p value for each command.
+ * Each control command may be set to manual or automatic. See the definition of \ref k4a_color_control_command_t on
+ * how to interpret the \p value for each command.
  *
  * \remarks
- * Some control commands are only supported in manual mode. When a command is in automatic mode, the \p value for that
- * command is not valid.
+ * Some control commands are only supported in manual mode. When a command is in automatic mode, the \p value for
+ * that command is not valid.
  *
  * \remarks
- * Control values set on a device are reset only when the device is power cycled. The device will retain the settings
- * even if the \ref k4a_device_t is closed or the application is restarted.
+ * Control values set on a device are reset only when the device is power cycled. The device will retain the
+ * settings even if the \ref k4a_device_t is closed or the application is restarted.
  *
  * \relates k4a_device_t
  *

--- a/include/k4ainternal/color.h
+++ b/include/k4ainternal/color.h
@@ -118,6 +118,45 @@ void color_stop(color_t color_handle);
  */
 tickcounter_ms_t color_get_sensor_start_time_tick(const color_t color_handle);
 
+/** Gets the capabilities of the given color camera's control command setting.
+ *
+ * \param color_handle
+ * Handle to the color camera
+ *
+ * \param command
+ * The targeted color control command to read the the value for.
+ *
+ * \param support_auto
+ * Location to store whether the color sensor's control support auto mode or not.
+ * true if it supports auto mode, otherwise false.
+ *
+ * \param min_value
+ * Location to store the color sensor's control minimum value of /p command.
+ *
+ * \param max_value
+ * Location to store the color sensor's control maximum value of /p command.
+ *
+ * \param step_value
+ * Location to store the color sensor's control step value of /p command.
+ *
+ * \param default_value
+ * Location to store the color sensor's control default value of /p command.
+ *
+ * \param default_mode
+ * Location to store the color sensor's control default mode of /p command.
+ *
+ * \return ::K4A_RESULT_FAILED if the value could not be read. ::K4A_RESULT_SUCCEEDED if successful. Details of the
+ * error can be read from the debug output
+ */
+k4a_result_t color_get_control_capabilities(const color_t color_handle,
+                                            const k4a_color_control_command_t command,
+                                            bool *support_auto,
+                                            int32_t *min_value,
+                                            int32_t *max_value,
+                                            int32_t *step_value,
+                                            int32_t *default_value,
+                                            k4a_color_control_mode_t *default_mode);
+
 /** Gets the value of the given color camera's control command setting.
  *
  * \param color_handle

--- a/include/k4ainternal/color.h
+++ b/include/k4ainternal/color.h
@@ -126,7 +126,7 @@ tickcounter_ms_t color_get_sensor_start_time_tick(const color_t color_handle);
  * \param command
  * The targeted color control command to read the the value for.
  *
- * \param support_auto
+ * \param supports_auto
  * Location to store whether the color sensor's control support auto mode or not.
  * true if it supports auto mode, otherwise false.
  *
@@ -150,7 +150,7 @@ tickcounter_ms_t color_get_sensor_start_time_tick(const color_t color_handle);
  */
 k4a_result_t color_get_control_capabilities(const color_t color_handle,
                                             const k4a_color_control_command_t command,
-                                            bool *support_auto,
+                                            bool *supports_auto,
                                             int32_t *min_value,
                                             int32_t *max_value,
                                             int32_t *step_value,

--- a/src/color/color.cpp
+++ b/src/color/color.cpp
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <assert.h>
 #include <new>
+#include <array>
 
 #include "color_priv.h"
 
@@ -33,7 +34,7 @@ typedef struct _color_context_t
     color_cb_streaming_capture_t *capture_ready_cb;
     void *capture_ready_cb_context;
     tickcounter_ms_t sensor_start_time_tick;
-
+    std::array<color_control_cap_t, K4A_COLOR_CONTROL_POWERLINE_FREQUENCY + 1> control_cap = {};
 #ifdef _WIN32
     Microsoft::WRL::ComPtr<CMFCameraReader> m_spCameraReader;
 #else
@@ -64,10 +65,7 @@ k4a_result_t color_create(TICK_COUNTER_HANDLE tick_handle,
         color->capture_ready_cb_context = capture_ready_context;
         color->sensor_start_time_tick = 0;
         color->tick = tick_handle;
-    }
 
-    if (K4A_SUCCEEDED(result))
-    {
 #ifdef _WIN32
         (void)(serial_number);
         static_assert(sizeof(guid_t) == sizeof(GUID), "Windows GUID and this guid_t are not the same");
@@ -226,6 +224,46 @@ tickcounter_ms_t color_get_sensor_start_time_tick(const color_t handle)
     RETURN_VALUE_IF_HANDLE_INVALID(0, color_t, handle);
     color_context_t *color = color_t_get_context(handle);
     return color->sensor_start_time_tick;
+}
+
+k4a_result_t color_get_control_capabilities(const color_t handle,
+                                            const k4a_color_control_command_t command,
+                                            bool *support_auto,
+                                            int32_t *min_value,
+                                            int32_t *max_value,
+                                            int32_t *step_value,
+                                            int32_t *default_value,
+                                            k4a_color_control_mode_t *default_mode)
+{
+    RETURN_VALUE_IF_HANDLE_INVALID(K4A_RESULT_FAILED, color_t, handle);
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED,
+                        command < K4A_COLOR_CONTROL_EXPOSURE_TIME_ABSOLUTE ||
+                            command > K4A_COLOR_CONTROL_POWERLINE_FREQUENCY);
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, support_auto == NULL);
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, min_value == NULL);
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, max_value == NULL);
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, step_value == NULL);
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, default_value == NULL);
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, default_mode == NULL);
+    k4a_result_t result = K4A_RESULT_SUCCEEDED;
+    color_context_t *color = color_t_get_context(handle);
+
+    if (color->control_cap[command].valid == false)
+    {
+        result = color->m_spCameraReader->GetCameraControlCapabilities(command, color->control_cap[command]);
+    }
+
+    if (K4A_SUCCEEDED(result))
+    {
+        *support_auto = color->control_cap[command].supportAuto;
+        *min_value = color->control_cap[command].minValue;
+        *max_value = color->control_cap[command].maxValue;
+        *step_value = color->control_cap[command].stepValue;
+        *default_value = color->control_cap[command].defaultValue;
+        *default_mode = color->control_cap[command].defaultMode;
+    }
+
+    return result;
 }
 
 k4a_result_t color_get_control(const color_t handle,

--- a/src/color/color.cpp
+++ b/src/color/color.cpp
@@ -228,7 +228,7 @@ tickcounter_ms_t color_get_sensor_start_time_tick(const color_t handle)
 
 k4a_result_t color_get_control_capabilities(const color_t handle,
                                             const k4a_color_control_command_t command,
-                                            bool *support_auto,
+                                            bool *supports_auto,
                                             int32_t *min_value,
                                             int32_t *max_value,
                                             int32_t *step_value,
@@ -239,7 +239,7 @@ k4a_result_t color_get_control_capabilities(const color_t handle,
     RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED,
                         command < K4A_COLOR_CONTROL_EXPOSURE_TIME_ABSOLUTE ||
                             command > K4A_COLOR_CONTROL_POWERLINE_FREQUENCY);
-    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, support_auto == NULL);
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, supports_auto == NULL);
     RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, min_value == NULL);
     RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, max_value == NULL);
     RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, step_value == NULL);
@@ -255,7 +255,7 @@ k4a_result_t color_get_control_capabilities(const color_t handle,
 
     if (K4A_SUCCEEDED(result))
     {
-        *support_auto = color->control_cap[command].supportAuto;
+        *supports_auto = color->control_cap[command].supportAuto;
         *min_value = color->control_cap[command].minValue;
         *max_value = color->control_cap[command].maxValue;
         *step_value = color->control_cap[command].stepValue;

--- a/src/color/color.cpp
+++ b/src/color/color.cpp
@@ -250,7 +250,7 @@ k4a_result_t color_get_control_capabilities(const color_t handle,
 
     if (color->control_cap[command].valid == false)
     {
-        result = color->m_spCameraReader->GetCameraControlCapabilities(command, color->control_cap[command]);
+        result = color->m_spCameraReader->GetCameraControlCapabilities(command, &(color->control_cap[command]));
     }
 
     if (K4A_SUCCEEDED(result))

--- a/src/color/color_priv.h
+++ b/src/color/color_priv.h
@@ -10,6 +10,17 @@
 extern "C" {
 #endif
 
+typedef struct _color_control_cap_t
+{
+    int32_t minValue;
+    int32_t maxValue;
+    int32_t stepValue;
+    int32_t defaultValue;
+    k4a_color_control_mode_t defaultMode;
+    bool supportAuto;
+    bool valid;
+} color_control_cap_t;
+
 /** Delivers a sample to the registered callback function when a capture is ready for processing.
  *
  * \param result

--- a/src/color/mfcamerareader.cpp
+++ b/src/color/mfcamerareader.cpp
@@ -566,9 +566,13 @@ k4a_result_t CMFCameraReader::GetCameraControlCapabilities(const k4a_color_contr
         // Convert KSProperty exposure time value to micro-second unit
         minValue = (LONG)(exp2f((float)minValue) * 1000000.0f);
         maxValue = (LONG)(exp2f((float)maxValue) * 1000000.0f);
-        stepValue = 1;
         defaultValue = (LONG)(exp2f((float)defaultValue) * 1000000.0f);
         defaultMode = K4A_COLOR_CONTROL_MODE_AUTO;
+
+        // Windows KsProperty uses exposure time value as log base 2 seconds, which is not linear.
+        // But K4A color control API allow to use micro sec unit exposure time.
+        // Set step value to 1.
+        stepValue = 1;
     }
     break;
     case K4A_COLOR_CONTROL_BRIGHTNESS:

--- a/src/color/mfcamerareader.cpp
+++ b/src/color/mfcamerareader.cpp
@@ -540,7 +540,7 @@ void CMFCameraReader::Stop()
 }
 
 k4a_result_t CMFCameraReader::GetCameraControlCapabilities(const k4a_color_control_command_t command,
-                                                           color_control_cap_t &capabilities)
+                                                           color_control_cap_t *capabilities)
 {
     HRESULT hr = S_OK;
     bool supportAuto = false;
@@ -549,6 +549,7 @@ k4a_result_t CMFCameraReader::GetCameraControlCapabilities(const k4a_color_contr
     ULONG stepValue = 0;
     LONG defaultValue = 0;
     k4a_color_control_mode_t defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, capabilities == NULL);
 
     switch (command)
     {
@@ -667,7 +668,7 @@ k4a_result_t CMFCameraReader::GetCameraControlCapabilities(const k4a_color_contr
         maxValue = 0;
         stepValue = 0;
         defaultValue = 0;
-        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and do nothing.");
+        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and does nothing.");
     }
     break;
     default:
@@ -676,13 +677,13 @@ k4a_result_t CMFCameraReader::GetCameraControlCapabilities(const k4a_color_contr
 
     if (SUCCEEDED(hr))
     {
-        capabilities.supportAuto = supportAuto;
-        capabilities.minValue = minValue;
-        capabilities.maxValue = maxValue;
-        capabilities.stepValue = stepValue;
-        capabilities.defaultValue = defaultValue;
-        capabilities.defaultMode = defaultMode;
-        capabilities.valid = true;
+        capabilities->supportAuto = supportAuto;
+        capabilities->minValue = minValue;
+        capabilities->maxValue = maxValue;
+        capabilities->stepValue = stepValue;
+        capabilities->defaultValue = defaultValue;
+        capabilities->defaultMode = defaultMode;
+        capabilities->valid = true;
     }
 
     return k4aResultFromHRESULT(hr);
@@ -792,7 +793,7 @@ k4a_result_t CMFCameraReader::GetCameraControl(const k4a_color_control_command_t
     case K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY:
     {
         propertyValue = 0; // return 0 for current firmware behaviour - framerate priority.
-        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and do nothing.");
+        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and does nothing.");
     }
     break;
     default:
@@ -910,7 +911,7 @@ k4a_result_t CMFCameraReader::SetCameraControl(const k4a_color_control_command_t
     break;
     case K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY:
     {
-        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and do nothing.");
+        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and does nothing.");
     }
     break;
     default:

--- a/src/color/mfcamerareader.cpp
+++ b/src/color/mfcamerareader.cpp
@@ -539,6 +539,158 @@ void CMFCameraReader::Stop()
     }
 }
 
+k4a_result_t CMFCameraReader::GetCameraControlCapabilities(const k4a_color_control_command_t command,
+                                                           color_control_cap_t &capabilities)
+{
+    HRESULT hr = S_OK;
+    bool supportAuto = false;
+    LONG minValue = 0;
+    LONG maxValue = 0;
+    ULONG stepValue = 0;
+    LONG defaultValue = 0;
+    k4a_color_control_mode_t defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+
+    switch (command)
+    {
+    case K4A_COLOR_CONTROL_EXPOSURE_TIME_ABSOLUTE:
+    {
+        hr = GetCameraControlCap(PROPSETID_VIDCAP_CAMERACONTROL,
+                                 KSPROPERTY_CAMERACONTROL_EXPOSURE,
+                                 &supportAuto,
+                                 &minValue,
+                                 &maxValue,
+                                 &stepValue,
+                                 &defaultValue);
+
+        // Convert KSProperty exposure time value to micro-second unit
+        minValue = (LONG)(exp2f((float)minValue) * 1000000.0f);
+        maxValue = (LONG)(exp2f((float)maxValue) * 1000000.0f);
+        stepValue = 1;
+        defaultValue = (LONG)(exp2f((float)defaultValue) * 1000000.0f);
+        defaultMode = K4A_COLOR_CONTROL_MODE_AUTO;
+    }
+    break;
+    case K4A_COLOR_CONTROL_BRIGHTNESS:
+    {
+        hr = GetCameraControlCap(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                 KSPROPERTY_VIDEOPROCAMP_BRIGHTNESS,
+                                 &supportAuto,
+                                 &minValue,
+                                 &maxValue,
+                                 &stepValue,
+                                 &defaultValue);
+    }
+    break;
+    case K4A_COLOR_CONTROL_CONTRAST:
+    {
+        hr = GetCameraControlCap(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                 KSPROPERTY_VIDEOPROCAMP_CONTRAST,
+                                 &supportAuto,
+                                 &minValue,
+                                 &maxValue,
+                                 &stepValue,
+                                 &defaultValue);
+    }
+    break;
+    case K4A_COLOR_CONTROL_SATURATION:
+    {
+        hr = GetCameraControlCap(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                 KSPROPERTY_VIDEOPROCAMP_SATURATION,
+                                 &supportAuto,
+                                 &minValue,
+                                 &maxValue,
+                                 &stepValue,
+                                 &defaultValue);
+    }
+    break;
+    case K4A_COLOR_CONTROL_SHARPNESS:
+    {
+        hr = GetCameraControlCap(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                 KSPROPERTY_VIDEOPROCAMP_SHARPNESS,
+                                 &supportAuto,
+                                 &minValue,
+                                 &maxValue,
+                                 &stepValue,
+                                 &defaultValue);
+    }
+    break;
+    case K4A_COLOR_CONTROL_WHITEBALANCE:
+    {
+        hr = GetCameraControlCap(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                 KSPROPERTY_VIDEOPROCAMP_WHITEBALANCE,
+                                 &supportAuto,
+                                 &minValue,
+                                 &maxValue,
+                                 &stepValue,
+                                 &defaultValue);
+
+        defaultMode = K4A_COLOR_CONTROL_MODE_AUTO;
+    }
+    break;
+    case K4A_COLOR_CONTROL_BACKLIGHT_COMPENSATION:
+    {
+        hr = GetCameraControlCap(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                 KSPROPERTY_VIDEOPROCAMP_BACKLIGHT_COMPENSATION,
+                                 &supportAuto,
+                                 &minValue,
+                                 &maxValue,
+                                 &stepValue,
+                                 &defaultValue);
+    }
+    break;
+    case K4A_COLOR_CONTROL_GAIN:
+    {
+        hr = GetCameraControlCap(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                 KSPROPERTY_VIDEOPROCAMP_GAIN,
+                                 &supportAuto,
+                                 &minValue,
+                                 &maxValue,
+                                 &stepValue,
+                                 &defaultValue);
+    }
+    break;
+    case K4A_COLOR_CONTROL_POWERLINE_FREQUENCY:
+    {
+        hr = GetCameraControlCap(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                 KSPROPERTY_VIDEOPROCAMP_POWERLINE_FREQUENCY,
+                                 &supportAuto,
+                                 &minValue,
+                                 &maxValue,
+                                 &stepValue,
+                                 &defaultValue);
+    }
+    break;
+    case K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY:
+    {
+        supportAuto = false;
+        minValue = 0;
+        maxValue = 0;
+        stepValue = 0;
+        defaultValue = 0;
+        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and do nothing.");
+    }
+    break;
+    default:
+        return K4A_RESULT_FAILED;
+    }
+
+    if (SUCCEEDED(hr))
+    {
+        capabilities.supportAuto = supportAuto;
+        capabilities.minValue = minValue;
+        capabilities.maxValue = maxValue;
+        capabilities.stepValue = stepValue;
+        capabilities.defaultValue = defaultValue;
+        capabilities.defaultMode = defaultMode;
+        // capabilities.valid = true;
+    }
+
+    return k4aResultFromHRESULT(hr);
+}
+
+// PROPSETID_VIDCAP_CAMERACONTROL
+// PROPSETID_VIDCAP_VIDEOPROCAMP
+
 k4a_result_t CMFCameraReader::GetCameraControl(const k4a_color_control_command_t command,
                                                k4a_color_control_mode_t *mode,
                                                int32_t *pValue)
@@ -546,7 +698,6 @@ k4a_result_t CMFCameraReader::GetCameraControl(const k4a_color_control_command_t
     HRESULT hr = S_OK;
     LONG propertyValue = 0;
     ULONG flags = 0;
-    ULONG capability = 0;
 
     // clear return
     *mode = K4A_COLOR_CONTROL_MODE_MANUAL;
@@ -556,7 +707,11 @@ k4a_result_t CMFCameraReader::GetCameraControl(const k4a_color_control_command_t
     {
     case K4A_COLOR_CONTROL_EXPOSURE_TIME_ABSOLUTE:
     {
-        hr = GetCameraControlValue(KSPROPERTY_CAMERACONTROL_EXPOSURE, &propertyValue, &flags, &capability);
+        hr = GetCameraControlValue(PROPSETID_VIDCAP_CAMERACONTROL,
+                                   KSPROPERTY_CAMERACONTROL_EXPOSURE,
+                                   &propertyValue,
+                                   &flags,
+                                   nullptr);
 
         // Convert KSProperty exposure time value to micro-second unit
         propertyValue = (LONG)(exp2f((float)propertyValue) * 1000000.0f);
@@ -564,42 +719,74 @@ k4a_result_t CMFCameraReader::GetCameraControl(const k4a_color_control_command_t
     break;
     case K4A_COLOR_CONTROL_BRIGHTNESS:
     {
-        hr = GetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_BRIGHTNESS, &propertyValue, &flags, &capability);
+        hr = GetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_BRIGHTNESS,
+                                   &propertyValue,
+                                   &flags,
+                                   nullptr);
     }
     break;
     case K4A_COLOR_CONTROL_CONTRAST:
     {
-        hr = GetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_CONTRAST, &propertyValue, &flags, &capability);
+        hr = GetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_CONTRAST,
+                                   &propertyValue,
+                                   &flags,
+                                   nullptr);
     }
     break;
     case K4A_COLOR_CONTROL_SATURATION:
     {
-        hr = GetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_SATURATION, &propertyValue, &flags, &capability);
+        hr = GetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_SATURATION,
+                                   &propertyValue,
+                                   &flags,
+                                   nullptr);
     }
     break;
     case K4A_COLOR_CONTROL_SHARPNESS:
     {
-        hr = GetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_SHARPNESS, &propertyValue, &flags, &capability);
+        hr = GetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_SHARPNESS,
+                                   &propertyValue,
+                                   &flags,
+                                   nullptr);
     }
     break;
     case K4A_COLOR_CONTROL_WHITEBALANCE:
     {
-        hr = GetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_WHITEBALANCE, &propertyValue, &flags, &capability);
+        hr = GetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_WHITEBALANCE,
+                                   &propertyValue,
+                                   &flags,
+                                   nullptr);
     }
     break;
     case K4A_COLOR_CONTROL_BACKLIGHT_COMPENSATION:
     {
-        hr = GetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_BACKLIGHT_COMPENSATION, &propertyValue, &flags, &capability);
+        hr = GetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_BACKLIGHT_COMPENSATION,
+                                   &propertyValue,
+                                   &flags,
+                                   nullptr);
     }
     break;
     case K4A_COLOR_CONTROL_GAIN:
     {
-        hr = GetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_GAIN, &propertyValue, &flags, &capability);
+        hr = GetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_GAIN,
+                                   &propertyValue,
+                                   &flags,
+                                   nullptr);
     }
     break;
     case K4A_COLOR_CONTROL_POWERLINE_FREQUENCY:
     {
-        hr = GetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_POWERLINE_FREQUENCY, &propertyValue, &flags, &capability);
+        hr = GetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_POWERLINE_FREQUENCY,
+                                   &propertyValue,
+                                   &flags,
+                                   nullptr);
     }
     break;
     case K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY:
@@ -654,47 +841,71 @@ k4a_result_t CMFCameraReader::SetCameraControl(const k4a_color_control_command_t
     case K4A_COLOR_CONTROL_EXPOSURE_TIME_ABSOLUTE:
     {
         // Convert micro-second unit to KSProperty exposure time value
-        hr = SetCameraControlValue(KSPROPERTY_CAMERACONTROL_EXPOSURE, (LONG)log2f((float)newValue * 0.000001f), flags);
+        hr = SetCameraControlValue(PROPSETID_VIDCAP_CAMERACONTROL,
+                                   KSPROPERTY_CAMERACONTROL_EXPOSURE,
+                                   (LONG)log2f((float)newValue * 0.000001f),
+                                   flags);
     }
     break;
     case K4A_COLOR_CONTROL_BRIGHTNESS:
     {
-        hr = SetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_BRIGHTNESS, (LONG)newValue, flags);
+        hr = SetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_BRIGHTNESS,
+                                   (LONG)newValue,
+                                   flags);
     }
     break;
     case K4A_COLOR_CONTROL_CONTRAST:
     {
-        hr = SetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_CONTRAST, (LONG)newValue, flags);
+        hr = SetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_CONTRAST,
+                                   (LONG)newValue,
+                                   flags);
     }
     break;
     case K4A_COLOR_CONTROL_SATURATION:
     {
-        hr = SetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_SATURATION, (LONG)newValue, flags);
+        hr = SetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_SATURATION,
+                                   (LONG)newValue,
+                                   flags);
     }
     break;
     case K4A_COLOR_CONTROL_SHARPNESS:
     {
-        hr = SetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_SHARPNESS, (LONG)newValue, flags);
+        hr = SetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_SHARPNESS,
+                                   (LONG)newValue,
+                                   flags);
     }
     break;
     case K4A_COLOR_CONTROL_WHITEBALANCE:
     {
-        hr = SetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_WHITEBALANCE, (LONG)newValue, flags);
+        hr = SetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_WHITEBALANCE,
+                                   (LONG)newValue,
+                                   flags);
     }
     break;
     case K4A_COLOR_CONTROL_BACKLIGHT_COMPENSATION:
     {
-        hr = SetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_BACKLIGHT_COMPENSATION, (LONG)newValue, flags);
+        hr = SetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_BACKLIGHT_COMPENSATION,
+                                   (LONG)newValue,
+                                   flags);
     }
     break;
     case K4A_COLOR_CONTROL_GAIN:
     {
-        hr = SetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_GAIN, (LONG)newValue, flags);
+        hr = SetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP, KSPROPERTY_VIDEOPROCAMP_GAIN, (LONG)newValue, flags);
     }
     break;
     case K4A_COLOR_CONTROL_POWERLINE_FREQUENCY:
     {
-        hr = SetVideoProcAmpValue(KSPROPERTY_VIDEOPROCAMP_POWERLINE_FREQUENCY, (LONG)newValue, flags);
+        hr = SetCameraControlValue(PROPSETID_VIDCAP_VIDEOPROCAMP,
+                                   KSPROPERTY_VIDEOPROCAMP_POWERLINE_FREQUENCY,
+                                   (LONG)newValue,
+                                   flags);
     }
     break;
     case K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY:
@@ -1098,68 +1309,82 @@ done:
     return hr;
 }
 
-HRESULT CMFCameraReader::GetVideoProcAmpValue(const KSPROPERTY_VIDCAP_VIDEOPROCAMP PropertyId,
-                                              LONG *pValue,
-                                              ULONG *pFlags,
-                                              ULONG *pCapability)
+// KS property structures for querying the range and default values
+// of either the videoprocamp or cameracontrol properties.
+typedef struct _KsConrolMemberList
+{
+    KSPROPERTY_DESCRIPTION desc;
+    KSPROPERTY_MEMBERSHEADER hdr;
+    KSPROPERTY_STEPPING_LONG step;
+} KsConrolMemberList, *PKsConrolMemberList;
+
+typedef struct _KsControlDefaultValue
+{
+    KSPROPERTY_DESCRIPTION desc;
+    KSPROPERTY_MEMBERSHEADER hdr;
+    long lValue;
+} KsControlDefaultValue;
+
+HRESULT CMFCameraReader::GetCameraControlCap(const GUID PropertySet,
+                                             const ULONG PropertyId,
+                                             bool *supportAuto,
+                                             LONG *minValue,
+                                             LONG *maxValue,
+                                             ULONG *stepValue,
+                                             LONG *defaultValue)
 {
     HRESULT hr = S_OK;
-    KSPROPERTY_VIDEOPROCAMP_S videoCamp = {};
-    videoCamp.Property.Set = PROPSETID_VIDCAP_VIDEOPROCAMP;
-    videoCamp.Property.Id = PropertyId;
-    videoCamp.Property.Flags = KSPROPERTY_TYPE_GET;
-    videoCamp.Value = -1;
-    ULONG retSize = 0;
+    KsConrolMemberList ksMemList = {};
+    KsControlDefaultValue ksDefault = {};
+    KSPROPERTY_CAMERACONTROL_S ksProp = {};
+    ULONG capability = 0;
+    ULONG cbReturned = 0;
 
-    if (SUCCEEDED(hr = m_spKsControl->KsProperty(
-                      (PKSPROPERTY)&videoCamp, sizeof(videoCamp), &videoCamp, sizeof(videoCamp), &retSize)))
+    ksProp.Property.Set = PropertySet;
+    ksProp.Property.Id = PropertyId;
+    ksProp.Property.Flags = KSPROPERTY_TYPE_BASICSUPPORT;
+
+    if (FAILED(hr = m_spKsControl->KsProperty(
+                      (PKSPROPERTY)&ksProp, sizeof(ksProp), &ksMemList, sizeof(ksMemList), &cbReturned)))
     {
-        if (pValue)
-        {
-            *pValue = videoCamp.Value;
-        }
+        LOG_ERROR("Failed to get control range: 0x%08x", hr);
+        return hr;
+    }
 
-        if (pFlags)
-        {
-            *pFlags = videoCamp.Flags;
-        }
+    ksProp.Property.Flags = KSPROPERTY_TYPE_DEFAULTVALUES;
+    if (FAILED(hr = m_spKsControl->KsProperty(
+                      (PKSPROPERTY)&ksProp, sizeof(ksProp), &ksDefault, sizeof(ksDefault), &cbReturned)))
+    {
+        LOG_ERROR("Failed to get control default values: 0x%08x", hr);
+        return hr;
+    }
 
-        if (pCapability)
-        {
-            *pCapability = videoCamp.Capabilities;
-        }
+    if (FAILED(hr = GetCameraControlValue(PropertySet, PropertyId, nullptr, nullptr, &capability)))
+    {
+        LOG_ERROR("Failed to get control capability flag: 0x%08x", hr);
+    }
+
+    if (SUCCEEDED(hr))
+    {
+        *minValue = ksMemList.step.Bounds.SignedMinimum;
+        *maxValue = ksMemList.step.Bounds.SignedMaximum;
+        *stepValue = ksMemList.step.SteppingDelta;
+        *defaultValue = ksDefault.lValue;
+        *supportAuto = !!(capability & KSPROPERTY_CAMERACONTROL_FLAGS_AUTO);
     }
 
     return hr;
 }
 
-HRESULT CMFCameraReader::SetVideoProcAmpValue(const KSPROPERTY_VIDCAP_VIDEOPROCAMP PropertyId,
-                                              LONG newValue,
-                                              ULONG newFlags)
-{
-    KSPROPERTY_VIDEOPROCAMP_S videoCamp = {};
-    videoCamp.Property.Set = PROPSETID_VIDCAP_VIDEOPROCAMP;
-    videoCamp.Property.Id = PropertyId;
-    videoCamp.Property.Flags = KSPROPERTY_TYPE_SET;
-    videoCamp.Value = newValue;
-    videoCamp.Flags = newFlags;
-    ULONG retSize = 0;
-
-    return m_spKsControl->KsProperty((PKSPROPERTY)&videoCamp,
-                                     sizeof(videoCamp),
-                                     &videoCamp,
-                                     sizeof(videoCamp),
-                                     &retSize);
-}
-
-HRESULT CMFCameraReader::GetCameraControlValue(const KSPROPERTY_VIDCAP_CAMERACONTROL PropertyId,
+HRESULT CMFCameraReader::GetCameraControlValue(const GUID PropertySet,
+                                               const ULONG PropertyId,
                                                LONG *pValue,
                                                ULONG *pFlags,
                                                ULONG *pCapability)
 {
     HRESULT hr = S_OK;
     KSPROPERTY_CAMERACONTROL_S videoControl = {};
-    videoControl.Property.Set = PROPSETID_VIDCAP_CAMERACONTROL;
+    videoControl.Property.Set = PropertySet;
     videoControl.Property.Id = PropertyId;
     videoControl.Property.Flags = KSPROPERTY_TYPE_GET;
     videoControl.Value = -1;
@@ -1187,12 +1412,11 @@ HRESULT CMFCameraReader::GetCameraControlValue(const KSPROPERTY_VIDCAP_CAMERACON
     return hr;
 }
 
-HRESULT CMFCameraReader::SetCameraControlValue(const KSPROPERTY_VIDCAP_CAMERACONTROL PropertyId,
-                                               LONG newValue,
-                                               ULONG newFlags)
+HRESULT
+CMFCameraReader::SetCameraControlValue(const GUID PropertySet, const ULONG PropertyId, LONG newValue, ULONG newFlags)
 {
     KSPROPERTY_CAMERACONTROL_S videoControl = {};
-    videoControl.Property.Set = PROPSETID_VIDCAP_CAMERACONTROL;
+    videoControl.Property.Set = PropertySet;
     videoControl.Property.Id = PropertyId;
     videoControl.Property.Flags = KSPROPERTY_TYPE_SET;
     videoControl.Value = newValue;

--- a/src/color/mfcamerareader.cpp
+++ b/src/color/mfcamerareader.cpp
@@ -1344,16 +1344,16 @@ HRESULT CMFCameraReader::GetCameraControlCap(const GUID PropertySet,
     ksProp.Property.Id = PropertyId;
     ksProp.Property.Flags = KSPROPERTY_TYPE_BASICSUPPORT;
 
-    if (FAILED(hr = m_spKsControl->KsProperty(
-                      (PKSPROPERTY)&ksProp, sizeof(ksProp), &ksMemList, sizeof(ksMemList), &cbReturned)))
+    if (FAILED(hr = m_spKsControl
+                        ->KsProperty((PKSPROPERTY)&ksProp, sizeof(ksProp), &ksMemList, sizeof(ksMemList), &cbReturned)))
     {
         LOG_ERROR("Failed to get control range: 0x%08x", hr);
         return hr;
     }
 
     ksProp.Property.Flags = KSPROPERTY_TYPE_DEFAULTVALUES;
-    if (FAILED(hr = m_spKsControl->KsProperty(
-                      (PKSPROPERTY)&ksProp, sizeof(ksProp), &ksDefault, sizeof(ksDefault), &cbReturned)))
+    if (FAILED(hr = m_spKsControl
+                        ->KsProperty((PKSPROPERTY)&ksProp, sizeof(ksProp), &ksDefault, sizeof(ksDefault), &cbReturned)))
     {
         LOG_ERROR("Failed to get control default values: 0x%08x", hr);
         return hr;

--- a/src/color/mfcamerareader.cpp
+++ b/src/color/mfcamerareader.cpp
@@ -682,7 +682,7 @@ k4a_result_t CMFCameraReader::GetCameraControlCapabilities(const k4a_color_contr
         capabilities.stepValue = stepValue;
         capabilities.defaultValue = defaultValue;
         capabilities.defaultMode = defaultMode;
-        // capabilities.valid = true;
+        capabilities.valid = true;
     }
 
     return k4aResultFromHRESULT(hr);

--- a/src/color/mfcamerareader.h
+++ b/src/color/mfcamerareader.h
@@ -95,7 +95,7 @@ public:
     void Shutdown();
 
     k4a_result_t GetCameraControlCapabilities(const k4a_color_control_command_t command,
-                                              color_control_cap_t &capabilities);
+                                              color_control_cap_t *capabilities);
 
     k4a_result_t GetCameraControl(const k4a_color_control_command_t command,
                                   k4a_color_control_mode_t *mode,

--- a/src/color/mfcamerareader.h
+++ b/src/color/mfcamerareader.h
@@ -94,6 +94,9 @@ public:
 
     void Shutdown();
 
+    k4a_result_t GetCameraControlCapabilities(const k4a_color_control_command_t command,
+                                              color_control_cap_t &capabilities);
+
     k4a_result_t GetCameraControl(const k4a_color_control_command_t command,
                                   k4a_color_control_mode_t *mode,
                                   int32_t *pValue);
@@ -119,19 +122,21 @@ private:
                               ULONG *pcbData);
 
     // Camera controls
-    HRESULT GetVideoProcAmpValue(const KSPROPERTY_VIDCAP_VIDEOPROCAMP PropertyId,
-                                 LONG *pValue,
-                                 ULONG *pFlags,
-                                 ULONG *pCapability);
+    HRESULT GetCameraControlCap(const GUID PropertySet,
+                                const ULONG PropertyId,
+                                bool *supportAuto,
+                                LONG *minValue,
+                                LONG *maxValue,
+                                ULONG *stepValue,
+                                LONG *defaultValue);
 
-    HRESULT SetVideoProcAmpValue(const KSPROPERTY_VIDCAP_VIDEOPROCAMP PropertyId, LONG newValue, ULONG newFlags);
-
-    HRESULT GetCameraControlValue(const KSPROPERTY_VIDCAP_CAMERACONTROL PropertyId,
+    HRESULT GetCameraControlValue(const GUID PropertySet,
+                                  const ULONG PropertyId,
                                   LONG *pValue,
                                   ULONG *pFlags,
                                   ULONG *pCapability);
 
-    HRESULT SetCameraControlValue(const KSPROPERTY_VIDCAP_CAMERACONTROL PropertyId, LONG newValue, ULONG newFlags);
+    HRESULT SetCameraControlValue(const GUID PropertySet, const ULONG PropertyId, LONG newValue, ULONG newFlags);
 
     k4a_result_t k4aResultFromHRESULT(const HRESULT hr)
     {

--- a/src/color/uvc_camerareader.cpp
+++ b/src/color/uvc_camerareader.cpp
@@ -223,9 +223,10 @@ void UVCCameraReader::Shutdown()
 }
 
 k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_control_command_t command,
-                                                           color_control_cap_t &capabilities)
+                                                           color_control_cap_t *capabilities)
 {
     uvc_error_t res = UVC_SUCCESS;
+    RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, capabilities == NULL);
 
     switch (command)
     {
@@ -247,12 +248,12 @@ k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_contr
         if (default_ae_mode == UVC_AUTO_EXPOSURE_MODE_MANUAL ||
             default_ae_mode == UVC_AUTO_EXPOSURE_MODE_SHUTTER_PRIORITY)
         {
-            capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+            capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
         }
         else if (default_ae_mode == UVC_AUTO_EXPOSURE_MODE_AUTO ||
                  default_ae_mode == UVC_AUTO_EXPOSURE_MODE_APERTURE_PRIORITY)
         {
-            capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_AUTO;
+            capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_AUTO;
         }
         else
         {
@@ -290,12 +291,12 @@ k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_contr
         }
 
         // 0.0001 sec to uSec
-        capabilities.supportAuto = true;
-        capabilities.minValue = (int32_t)(min_exposure_time * 100);
-        capabilities.maxValue = (int32_t)(max_exposure_time * 100);
-        capabilities.stepValue = (int32_t)(step_exposure_time * 100);
-        capabilities.defaultValue = (int32_t)(default_exposure_time * 100);
-        capabilities.valid = true;
+        capabilities->supportAuto = true;
+        capabilities->minValue = (int32_t)(min_exposure_time * 100);
+        capabilities->maxValue = (int32_t)(max_exposure_time * 100);
+        capabilities->stepValue = (int32_t)(step_exposure_time * 100);
+        capabilities->defaultValue = (int32_t)(default_exposure_time * 100);
+        capabilities->valid = true;
     }
     break;
     case K4A_COLOR_CONTROL_BRIGHTNESS:
@@ -332,13 +333,13 @@ k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_contr
             return K4A_RESULT_FAILED;
         }
 
-        capabilities.supportAuto = false;
-        capabilities.minValue = (int32_t)min_brightness;
-        capabilities.maxValue = (int32_t)max_brightness;
-        capabilities.stepValue = (int32_t)step_brightness;
-        capabilities.defaultValue = (int32_t)default_brightness;
-        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
-        capabilities.valid = true;
+        capabilities->supportAuto = false;
+        capabilities->minValue = (int32_t)min_brightness;
+        capabilities->maxValue = (int32_t)max_brightness;
+        capabilities->stepValue = (int32_t)step_brightness;
+        capabilities->defaultValue = (int32_t)default_brightness;
+        capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities->valid = true;
     }
     break;
     case K4A_COLOR_CONTROL_CONTRAST:
@@ -376,13 +377,13 @@ k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_contr
             return K4A_RESULT_FAILED;
         }
 
-        capabilities.supportAuto = false;
-        capabilities.minValue = (int32_t)min_contrast;
-        capabilities.maxValue = (int32_t)max_contrast;
-        capabilities.stepValue = (int32_t)step_contrast;
-        capabilities.defaultValue = (int32_t)default_contrast;
-        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
-        capabilities.valid = true;
+        capabilities->supportAuto = false;
+        capabilities->minValue = (int32_t)min_contrast;
+        capabilities->maxValue = (int32_t)max_contrast;
+        capabilities->stepValue = (int32_t)step_contrast;
+        capabilities->defaultValue = (int32_t)default_contrast;
+        capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities->valid = true;
     }
     break;
     case K4A_COLOR_CONTROL_SATURATION:
@@ -420,13 +421,13 @@ k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_contr
             return K4A_RESULT_FAILED;
         }
 
-        capabilities.supportAuto = false;
-        capabilities.minValue = (int32_t)min_saturation;
-        capabilities.maxValue = (int32_t)max_saturation;
-        capabilities.stepValue = (int32_t)step_saturation;
-        capabilities.defaultValue = (int32_t)default_saturation;
-        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
-        capabilities.valid = true;
+        capabilities->supportAuto = false;
+        capabilities->minValue = (int32_t)min_saturation;
+        capabilities->maxValue = (int32_t)max_saturation;
+        capabilities->stepValue = (int32_t)step_saturation;
+        capabilities->defaultValue = (int32_t)default_saturation;
+        capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities->valid = true;
     }
     break;
     case K4A_COLOR_CONTROL_SHARPNESS:
@@ -464,13 +465,13 @@ k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_contr
             return K4A_RESULT_FAILED;
         }
 
-        capabilities.supportAuto = false;
-        capabilities.minValue = (int32_t)min_sharpness;
-        capabilities.maxValue = (int32_t)max_sharpness;
-        capabilities.stepValue = (int32_t)step_sharpness;
-        capabilities.defaultValue = (int32_t)default_sharpness;
-        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
-        capabilities.valid = true;
+        capabilities->supportAuto = false;
+        capabilities->minValue = (int32_t)min_sharpness;
+        capabilities->maxValue = (int32_t)max_sharpness;
+        capabilities->stepValue = (int32_t)step_sharpness;
+        capabilities->defaultValue = (int32_t)default_sharpness;
+        capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities->valid = true;
     }
     break;
     case K4A_COLOR_CONTROL_WHITEBALANCE:
@@ -490,11 +491,11 @@ k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_contr
 
         if (default_wb_mode == 0)
         {
-            capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+            capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
         }
         else if (default_wb_mode == 1)
         {
-            capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_AUTO;
+            capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_AUTO;
         }
         else
         {
@@ -531,12 +532,12 @@ k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_contr
             return K4A_RESULT_FAILED;
         }
 
-        capabilities.supportAuto = true;
-        capabilities.minValue = min_white_balance;
-        capabilities.maxValue = max_white_balance;
-        capabilities.stepValue = step_white_balance;
-        capabilities.defaultValue = default_white_balance;
-        capabilities.valid = true;
+        capabilities->supportAuto = true;
+        capabilities->minValue = min_white_balance;
+        capabilities->maxValue = max_white_balance;
+        capabilities->stepValue = step_white_balance;
+        capabilities->defaultValue = default_white_balance;
+        capabilities->valid = true;
     }
     break;
     case K4A_COLOR_CONTROL_BACKLIGHT_COMPENSATION:
@@ -574,13 +575,13 @@ k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_contr
             return K4A_RESULT_FAILED;
         }
 
-        capabilities.supportAuto = false;
-        capabilities.minValue = (int32_t)min_backlight_compensation;
-        capabilities.maxValue = (int32_t)max_backlight_compensation;
-        capabilities.stepValue = (int32_t)step_backlight_compensation;
-        capabilities.defaultValue = (int32_t)default_backlight_compensation;
-        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
-        capabilities.valid = true;
+        capabilities->supportAuto = false;
+        capabilities->minValue = (int32_t)min_backlight_compensation;
+        capabilities->maxValue = (int32_t)max_backlight_compensation;
+        capabilities->stepValue = (int32_t)step_backlight_compensation;
+        capabilities->defaultValue = (int32_t)default_backlight_compensation;
+        capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities->valid = true;
     }
     break;
     case K4A_COLOR_CONTROL_GAIN:
@@ -618,13 +619,13 @@ k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_contr
             return K4A_RESULT_FAILED;
         }
 
-        capabilities.supportAuto = false;
-        capabilities.minValue = (int32_t)min_gain;
-        capabilities.maxValue = (int32_t)max_gain;
-        capabilities.stepValue = (int32_t)step_gain;
-        capabilities.defaultValue = (int32_t)default_gain;
-        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
-        capabilities.valid = true;
+        capabilities->supportAuto = false;
+        capabilities->minValue = (int32_t)min_gain;
+        capabilities->maxValue = (int32_t)max_gain;
+        capabilities->stepValue = (int32_t)step_gain;
+        capabilities->defaultValue = (int32_t)default_gain;
+        capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities->valid = true;
     }
     break;
     case K4A_COLOR_CONTROL_POWERLINE_FREQUENCY:
@@ -662,26 +663,26 @@ k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_contr
             return K4A_RESULT_FAILED;
         }
 
-        capabilities.supportAuto = false;
-        capabilities.minValue = (int32_t)min_powerline_freq;
-        capabilities.maxValue = (int32_t)max_powerline_freq;
-        capabilities.stepValue = (int32_t)step_powerline_freq;
-        capabilities.defaultValue = (int32_t)default_powerline_freq;
-        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
-        capabilities.valid = true;
+        capabilities->supportAuto = false;
+        capabilities->minValue = (int32_t)min_powerline_freq;
+        capabilities->maxValue = (int32_t)max_powerline_freq;
+        capabilities->stepValue = (int32_t)step_powerline_freq;
+        capabilities->defaultValue = (int32_t)default_powerline_freq;
+        capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities->valid = true;
     }
     break;
     case K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY:
     {
         // Deprecated control. Return 0 for all capabilities which is current behaviour.
-        capabilities.supportAuto = false;
-        capabilities.minValue = 0;
-        capabilities.maxValue = 0;
-        capabilities.stepValue = 0;
-        capabilities.defaultValue = 0;
-        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
-        capabilities.valid = true;
-        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and do nothing.", 0);
+        capabilities->supportAuto = false;
+        capabilities->minValue = 0;
+        capabilities->maxValue = 0;
+        capabilities->stepValue = 0;
+        capabilities->defaultValue = 0;
+        capabilities->defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities->valid = true;
+        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and does nothing.", 0);
     }
     break;
     default:
@@ -869,7 +870,7 @@ k4a_result_t UVCCameraReader::GetCameraControl(const k4a_color_control_command_t
     case K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY:
     {
         *pValue = 0;
-        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and do nothing.", 0);
+        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and does nothing.", 0);
     }
     break;
     default:
@@ -1082,7 +1083,7 @@ k4a_result_t UVCCameraReader::SetCameraControl(const k4a_color_control_command_t
         break;
     case K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY:
     {
-        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and do nothing.", 0);
+        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and does nothing.", 0);
     }
     break;
     default:

--- a/src/color/uvc_camerareader.cpp
+++ b/src/color/uvc_camerareader.cpp
@@ -222,6 +222,476 @@ void UVCCameraReader::Shutdown()
     }
 }
 
+k4a_result_t UVCCameraReader::GetCameraControlCapabilities(const k4a_color_control_command_t command,
+                                                           color_control_cap_t &capabilities)
+{
+    uvc_error_t res = UVC_SUCCESS;
+
+    switch (command)
+    {
+    case K4A_COLOR_CONTROL_EXPOSURE_TIME_ABSOLUTE:
+    {
+        uint8_t default_ae_mode;
+        uint32_t min_exposure_time;
+        uint32_t max_exposure_time;
+        uint32_t step_exposure_time;
+        uint32_t default_exposure_time;
+
+        res = uvc_get_ae_mode(m_pDeviceHandle, &default_ae_mode, UVC_GET_DEF);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get default auto exposure mode: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        if (default_ae_mode == UVC_AUTO_EXPOSURE_MODE_MANUAL ||
+            default_ae_mode == UVC_AUTO_EXPOSURE_MODE_SHUTTER_PRIORITY)
+        {
+            capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        }
+        else if (default_ae_mode == UVC_AUTO_EXPOSURE_MODE_AUTO ||
+                 default_ae_mode == UVC_AUTO_EXPOSURE_MODE_APERTURE_PRIORITY)
+        {
+            capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_AUTO;
+        }
+        else
+        {
+            LOG_ERROR("Invalid auto exposure mode returned: %d", default_ae_mode);
+            return K4A_RESULT_FAILED;
+        }
+
+        // Get range of exposure time value
+        res = uvc_get_exposure_abs(m_pDeviceHandle, &min_exposure_time, UVC_GET_MIN);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get min exposure time abs: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_exposure_abs(m_pDeviceHandle, &max_exposure_time, UVC_GET_MAX);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get max exposure time abs: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_exposure_abs(m_pDeviceHandle, &step_exposure_time, UVC_GET_RES);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get exposure time abs: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_exposure_abs(m_pDeviceHandle, &default_exposure_time, UVC_GET_DEF);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get default exposure time abs: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        // 0.0001 sec to uSec
+        capabilities.supportAuto = true;
+        capabilities.minValue = (int32_t)(min_exposure_time * 100);
+        capabilities.maxValue = (int32_t)(max_exposure_time * 100);
+        capabilities.stepValue = (int32_t)(step_exposure_time * 100);
+        capabilities.defaultValue = (int32_t)(default_exposure_time * 100);
+        capabilities.valid = true;
+    }
+    break;
+    case K4A_COLOR_CONTROL_BRIGHTNESS:
+    {
+        int16_t min_brightness;
+        int16_t max_brightness;
+        int16_t step_brightness;
+        int16_t default_brightness;
+        res = uvc_get_brightness(m_pDeviceHandle, &min_brightness, UVC_GET_MIN);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get min brightness: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_brightness(m_pDeviceHandle, &max_brightness, UVC_GET_MAX);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get max brightness: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_brightness(m_pDeviceHandle, &step_brightness, UVC_GET_RES);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get step brightness: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_brightness(m_pDeviceHandle, &default_brightness, UVC_GET_DEF);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get default brightness: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        capabilities.supportAuto = false;
+        capabilities.minValue = (int32_t)min_brightness;
+        capabilities.maxValue = (int32_t)max_brightness;
+        capabilities.stepValue = (int32_t)step_brightness;
+        capabilities.defaultValue = (int32_t)default_brightness;
+        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities.valid = true;
+    }
+    break;
+    case K4A_COLOR_CONTROL_CONTRAST:
+    {
+        uint16_t min_contrast;
+        uint16_t max_contrast;
+        uint16_t step_contrast;
+        uint16_t default_contrast;
+
+        res = uvc_get_contrast(m_pDeviceHandle, &min_contrast, UVC_GET_MIN);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get min contrast: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_contrast(m_pDeviceHandle, &max_contrast, UVC_GET_MAX);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get max contrast: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_contrast(m_pDeviceHandle, &step_contrast, UVC_GET_RES);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get step contrast: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_contrast(m_pDeviceHandle, &default_contrast, UVC_GET_DEF);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get default contrast: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        capabilities.supportAuto = false;
+        capabilities.minValue = (int32_t)min_contrast;
+        capabilities.maxValue = (int32_t)max_contrast;
+        capabilities.stepValue = (int32_t)step_contrast;
+        capabilities.defaultValue = (int32_t)default_contrast;
+        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities.valid = true;
+    }
+    break;
+    case K4A_COLOR_CONTROL_SATURATION:
+    {
+        uint16_t min_saturation;
+        uint16_t max_saturation;
+        uint16_t step_saturation;
+        uint16_t default_saturation;
+
+        res = uvc_get_saturation(m_pDeviceHandle, &min_saturation, UVC_GET_MIN);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get min saturation: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_saturation(m_pDeviceHandle, &max_saturation, UVC_GET_MAX);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get max saturation: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_saturation(m_pDeviceHandle, &step_saturation, UVC_GET_RES);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get step saturation: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_saturation(m_pDeviceHandle, &default_saturation, UVC_GET_DEF);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get default saturation: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        capabilities.supportAuto = false;
+        capabilities.minValue = (int32_t)min_saturation;
+        capabilities.maxValue = (int32_t)max_saturation;
+        capabilities.stepValue = (int32_t)step_saturation;
+        capabilities.defaultValue = (int32_t)default_saturation;
+        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities.valid = true;
+    }
+    break;
+    case K4A_COLOR_CONTROL_SHARPNESS:
+    {
+        uint16_t min_sharpness;
+        uint16_t max_sharpness;
+        uint16_t step_sharpness;
+        uint16_t default_sharpness;
+
+        res = uvc_get_sharpness(m_pDeviceHandle, &min_sharpness, UVC_GET_MIN);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get min sharpness: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_sharpness(m_pDeviceHandle, &max_sharpness, UVC_GET_MAX);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get max sharpness: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_sharpness(m_pDeviceHandle, &step_sharpness, UVC_GET_RES);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get step sharpness: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_sharpness(m_pDeviceHandle, &default_sharpness, UVC_GET_DEF);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get default sharpness: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        capabilities.supportAuto = false;
+        capabilities.minValue = (int32_t)min_sharpness;
+        capabilities.maxValue = (int32_t)max_sharpness;
+        capabilities.stepValue = (int32_t)step_sharpness;
+        capabilities.defaultValue = (int32_t)default_sharpness;
+        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities.valid = true;
+    }
+    break;
+    case K4A_COLOR_CONTROL_WHITEBALANCE:
+    {
+        uint8_t default_wb_mode;
+        uint16_t min_white_balance;
+        uint16_t max_white_balance;
+        uint16_t step_white_balance;
+        uint16_t default_white_balance;
+
+        res = uvc_get_white_balance_temperature_auto(m_pDeviceHandle, &default_wb_mode, UVC_GET_DEF);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get default auto white balance temperature mode: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        if (default_wb_mode == 0)
+        {
+            capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        }
+        else if (default_wb_mode == 1)
+        {
+            capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_AUTO;
+        }
+        else
+        {
+            LOG_ERROR("Invalid default auto white balance temperature mode returned: %d", default_wb_mode);
+            return K4A_RESULT_FAILED;
+        }
+
+        // Get range of white balance temperature value
+        res = uvc_get_white_balance_temperature(m_pDeviceHandle, &min_white_balance, UVC_GET_MIN);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get min white balance temperature: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_white_balance_temperature(m_pDeviceHandle, &max_white_balance, UVC_GET_MAX);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get max white balance temperature: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_white_balance_temperature(m_pDeviceHandle, &step_white_balance, UVC_GET_RES);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get step white balance temperature: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_white_balance_temperature(m_pDeviceHandle, &default_white_balance, UVC_GET_DEF);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get default white balance temperature: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        capabilities.supportAuto = true;
+        capabilities.minValue = min_white_balance;
+        capabilities.maxValue = max_white_balance;
+        capabilities.stepValue = step_white_balance;
+        capabilities.defaultValue = default_white_balance;
+        capabilities.valid = true;
+    }
+    break;
+    case K4A_COLOR_CONTROL_BACKLIGHT_COMPENSATION:
+    {
+        uint16_t min_backlight_compensation;
+        uint16_t max_backlight_compensation;
+        uint16_t step_backlight_compensation;
+        uint16_t default_backlight_compensation;
+
+        res = uvc_get_backlight_compensation(m_pDeviceHandle, &min_backlight_compensation, UVC_GET_MIN);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get min backlight compensation: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_backlight_compensation(m_pDeviceHandle, &max_backlight_compensation, UVC_GET_MAX);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get max backlight compensation: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_backlight_compensation(m_pDeviceHandle, &step_backlight_compensation, UVC_GET_RES);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get step backlight compensation: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_backlight_compensation(m_pDeviceHandle, &default_backlight_compensation, UVC_GET_DEF);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get default backlight compensation: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        capabilities.supportAuto = false;
+        capabilities.minValue = (int32_t)min_backlight_compensation;
+        capabilities.maxValue = (int32_t)max_backlight_compensation;
+        capabilities.stepValue = (int32_t)step_backlight_compensation;
+        capabilities.defaultValue = (int32_t)default_backlight_compensation;
+        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities.valid = true;
+    }
+    break;
+    case K4A_COLOR_CONTROL_GAIN:
+    {
+        uint16_t min_gain;
+        uint16_t max_gain;
+        uint16_t step_gain;
+        uint16_t default_gain;
+
+        res = uvc_get_gain(m_pDeviceHandle, &min_gain, UVC_GET_MIN);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get min gain: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_gain(m_pDeviceHandle, &max_gain, UVC_GET_MAX);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get max gain: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_gain(m_pDeviceHandle, &step_gain, UVC_GET_RES);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get step gain: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_gain(m_pDeviceHandle, &default_gain, UVC_GET_DEF);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get default gain: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        capabilities.supportAuto = false;
+        capabilities.minValue = (int32_t)min_gain;
+        capabilities.maxValue = (int32_t)max_gain;
+        capabilities.stepValue = (int32_t)step_gain;
+        capabilities.defaultValue = (int32_t)default_gain;
+        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities.valid = true;
+    }
+    break;
+    case K4A_COLOR_CONTROL_POWERLINE_FREQUENCY:
+    {
+        uint8_t min_powerline_freq;
+        uint8_t max_powerline_freq;
+        uint8_t step_powerline_freq;
+        uint8_t default_powerline_freq;
+
+        res = uvc_get_power_line_frequency(m_pDeviceHandle, &min_powerline_freq, UVC_GET_MIN);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get min powerline frequency: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_power_line_frequency(m_pDeviceHandle, &max_powerline_freq, UVC_GET_MAX);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get max powerline frequency: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_power_line_frequency(m_pDeviceHandle, &step_powerline_freq, UVC_GET_RES);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get step powerline frequency: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        res = uvc_get_power_line_frequency(m_pDeviceHandle, &default_powerline_freq, UVC_GET_DEF);
+        if (res < 0)
+        {
+            LOG_ERROR("Failed to get default powerline frequency: %s", uvc_strerror(res));
+            return K4A_RESULT_FAILED;
+        }
+
+        capabilities.supportAuto = false;
+        capabilities.minValue = (int32_t)min_powerline_freq;
+        capabilities.maxValue = (int32_t)max_powerline_freq;
+        capabilities.stepValue = (int32_t)step_powerline_freq;
+        capabilities.defaultValue = (int32_t)default_powerline_freq;
+        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities.valid = true;
+    }
+    break;
+    case K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY:
+    {
+        // Deprecated control. Return 0 for all capabilities which is current behaviour.
+        capabilities.supportAuto = false;
+        capabilities.minValue = 0;
+        capabilities.maxValue = 0;
+        capabilities.stepValue = 0;
+        capabilities.defaultValue = 0;
+        capabilities.defaultMode = K4A_COLOR_CONTROL_MODE_MANUAL;
+        capabilities.valid = true;
+        LOG_WARNING("K4A_COLOR_CONTROL_AUTO_EXPOSURE_PRIORITY is deprecated and do nothing.", 0);
+    }
+    break;
+    default:
+        LOG_ERROR("Unsupported control: %d\n", command);
+        return K4A_RESULT_FAILED;
+    }
+
+    return K4A_RESULT_SUCCEEDED;
+}
+
 k4a_result_t UVCCameraReader::GetCameraControl(const k4a_color_control_command_t command,
                                                k4a_color_control_mode_t *mode,
                                                int32_t *pValue)
@@ -588,6 +1058,15 @@ k4a_result_t UVCCameraReader::SetCameraControl(const k4a_color_control_command_t
     case K4A_COLOR_CONTROL_POWERLINE_FREQUENCY:
         if (mode == K4A_COLOR_CONTROL_MODE_MANUAL)
         {
+            if (newValue == 0)
+            {
+                // Even firmware does not able to disable power line frequncy control,
+                // value zero is accepted.
+                // Return failed unsupported value.
+                LOG_ERROR("Can not disable Powerline Frequency Control", 0);
+                return K4A_RESULT_FAILED;
+            }
+
             res = uvc_set_power_line_frequency(m_pDeviceHandle, (uint8_t)newValue);
             if (res < 0)
             {

--- a/src/color/uvc_camerareader.h
+++ b/src/color/uvc_camerareader.h
@@ -33,7 +33,7 @@ public:
     void Shutdown();
 
     k4a_result_t GetCameraControlCapabilities(const k4a_color_control_command_t command,
-                                              color_control_cap_t &capabilities);
+                                              color_control_cap_t *capabilities);
 
     k4a_result_t GetCameraControl(const k4a_color_control_command_t command,
                                   k4a_color_control_mode_t *mode,

--- a/src/color/uvc_camerareader.h
+++ b/src/color/uvc_camerareader.h
@@ -32,6 +32,9 @@ public:
 
     void Shutdown();
 
+    k4a_result_t GetCameraControlCapabilities(const k4a_color_control_command_t command,
+                                              color_control_cap_t &capabilities);
+
     k4a_result_t GetCameraControl(const k4a_color_control_command_t command,
                                   k4a_color_control_mode_t *mode,
                                   int32_t *pValue);

--- a/src/sdk/k4a.c
+++ b/src/sdk/k4a.c
@@ -797,6 +797,22 @@ k4a_result_t k4a_device_get_sync_jack(k4a_device_t device_handle,
         colormcu_get_external_sync_jack_state(device->colormcu, sync_in_jack_connected, sync_out_jack_connected));
 }
 
+k4a_result_t k4a_device_get_color_control_capabilities(k4a_device_t device_handle,
+                                                       k4a_color_control_command_t command,
+                                                       bool *support_auto,
+                                                       int32_t *min_value,
+                                                       int32_t *max_value,
+                                                       int32_t *step_value,
+                                                       int32_t *default_value,
+                                                       k4a_color_control_mode_t *default_mode)
+{
+    RETURN_VALUE_IF_HANDLE_INVALID(K4A_RESULT_FAILED, k4a_device_t, device_handle);
+    k4a_context_t *device = k4a_device_t_get_context(device_handle);
+
+    return TRACE_CALL(color_get_control_capabilities(
+        device->color, command, support_auto, min_value, max_value, step_value, default_value, default_mode));
+}
+
 k4a_result_t k4a_device_get_color_control(k4a_device_t device_handle,
                                           k4a_color_control_command_t command,
                                           k4a_color_control_mode_t *mode,

--- a/src/sdk/k4a.c
+++ b/src/sdk/k4a.c
@@ -799,7 +799,7 @@ k4a_result_t k4a_device_get_sync_jack(k4a_device_t device_handle,
 
 k4a_result_t k4a_device_get_color_control_capabilities(k4a_device_t device_handle,
                                                        k4a_color_control_command_t command,
-                                                       bool *support_auto,
+                                                       bool *supports_auto,
                                                        int32_t *min_value,
                                                        int32_t *max_value,
                                                        int32_t *step_value,
@@ -810,7 +810,7 @@ k4a_result_t k4a_device_get_color_control_capabilities(k4a_device_t device_handl
     k4a_context_t *device = k4a_device_t_get_context(device_handle);
 
     return TRACE_CALL(color_get_control_capabilities(
-        device->color, command, support_auto, min_value, max_value, step_value, default_value, default_mode));
+        device->color, command, supports_auto, min_value, max_value, step_value, default_value, default_mode));
 }
 
 k4a_result_t k4a_device_get_color_control(k4a_device_t device_handle,

--- a/tests/ColorTests/FunctionalTest/color_ft.cpp
+++ b/tests/ColorTests/FunctionalTest/color_ft.cpp
@@ -619,6 +619,8 @@ TEST_P(color_control_test, control_test)
     int32_t step_value;
     int32_t default_value;
     k4a_color_control_mode_t default_mode = K4A_COLOR_CONTROL_MODE_AUTO;
+    int32_t current_value;
+    k4a_color_control_mode_t current_mode = K4A_COLOR_CONTROL_MODE_MANUAL;
     bool supports_auto;
     int32_t value = 0;
 
@@ -636,6 +638,14 @@ TEST_P(color_control_test, control_test)
                                                         &step_value,
                                                         &default_value,
                                                         &default_mode));
+
+    EXPECT_EQ(K4A_RESULT_SUCCEEDED, k4a_device_get_color_control(m_device, as.command, &current_mode, &current_value));
+
+    // Verify default values
+    EXPECT_EQ(current_mode, default_mode) << "Current mode (" << current_mode << ") is not equal to default mode ("
+                                          << default_mode << "), please reset device before running test.\n";
+    EXPECT_EQ(current_value, default_value) << "Current value (" << current_value << ") is not equal to default value ("
+                                            << default_value << "), please reset device before running test.\n";
 
     if (supports_auto)
     {
@@ -688,7 +698,6 @@ TEST_P(color_control_test, control_test)
             EXPECT_EQ(control_mode, K4A_COLOR_CONTROL_MODE_MANUAL);
 
             // LibUVC exposure time camera control has 0.0001 sec precision
-            // EXPECT_EQ(value, (int32_t)(exp2f((float)testValue) * 10000.0f) * 100);
             EXPECT_EQ(value, testValue);
         }
 #endif
@@ -723,7 +732,15 @@ TEST_P(color_control_test, control_test)
     }
 
     // Recover to initial value
-    EXPECT_EQ(K4A_RESULT_SUCCEEDED, k4a_device_set_color_control(m_device, as.command, default_mode, default_value));
+    EXPECT_EQ(K4A_RESULT_SUCCEEDED,
+              k4a_device_set_color_control(m_device, as.command, K4A_COLOR_CONTROL_MODE_MANUAL, default_value));
+
+    // If default mode is not manual, recover color control mode as well
+    if (default_mode != K4A_COLOR_CONTROL_MODE_MANUAL)
+    {
+        EXPECT_EQ(K4A_RESULT_SUCCEEDED,
+                  k4a_device_set_color_control(m_device, as.command, default_mode, default_value));
+    }
 }
 
 INSTANTIATE_TEST_CASE_P(color_control,

--- a/tests/ColorTests/FunctionalTest/color_ft.cpp
+++ b/tests/ColorTests/FunctionalTest/color_ft.cpp
@@ -619,7 +619,7 @@ TEST_P(color_control_test, control_test)
     int32_t step_value;
     int32_t default_value;
     k4a_color_control_mode_t default_mode = K4A_COLOR_CONTROL_MODE_AUTO;
-    bool support_auto;
+    bool supports_auto;
     int32_t value = 0;
 
     // Invalid device handle test
@@ -630,14 +630,14 @@ TEST_P(color_control_test, control_test)
     EXPECT_EQ(K4A_RESULT_SUCCEEDED,
               k4a_device_get_color_control_capabilities(m_device,
                                                         as.command,
-                                                        &support_auto,
+                                                        &supports_auto,
                                                         &min_value,
                                                         &max_value,
                                                         &step_value,
                                                         &default_value,
                                                         &default_mode));
 
-    if (support_auto)
+    if (supports_auto)
     {
         EXPECT_EQ(K4A_RESULT_SUCCEEDED,
                   k4a_device_set_color_control(m_device, as.command, K4A_COLOR_CONTROL_MODE_AUTO, 0));

--- a/tests/ColorTests/FunctionalTest/color_ft.cpp
+++ b/tests/ColorTests/FunctionalTest/color_ft.cpp
@@ -675,7 +675,7 @@ TEST_P(color_control_test, control_test)
         }
 #else
         // Test valid range
-        step_value *= 3;    // skip test to do not too many test cases
+        step_value *= 3; // skip test to do not too many test cases
         for (int32_t testValue = min_value; testValue <= max_value; testValue += step_value)
         {
             // Set test value


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #216 

### Description of the changes:
- Add k4a_device_get_color_control_capabilities() API to query color camera control capabilities

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
color functional test (color_ft) include testing this feature.
