### PR TITLE
Fix error C2001 on multibyte character environment

### DIFF
--- a/extern/libusb/CMakeLists.txt
+++ b/extern/libusb/CMakeLists.txt
@@ -29,6 +29,8 @@ if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
 
     target_compile_definitions(LibUSB PRIVATE "_LIB" "_CRT_SECURE_NO_WARNINGS" "WINVER=0x0501" "_WIN32_WINNT=0x0501")
 
+    target_compile_options(LibUSB PRIVATE "/source-charset:utf-8")
+
 elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     target_sources(LibUSB PRIVATE
         "${CMAKE_CURRENT_SOURCE_DIR}/src/libusb/os/poll_posix.c"


### PR DESCRIPTION
## Fixes #320
Fix error C2001 on multibyte character environment by add compile option to specify character set. 

### Description of the changes:
- Add compiler option <code>/source-charset:utf-8</code> when build on Windows.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
**(Sorry, I can't tests with device because Azure Kinect is not released in Japan.)**

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

