### PR TITLE
Enabling color_ft to run on Linux

### DIFF
--- a/tests/ColorTests/FunctionalTest/CMakeLists.txt
+++ b/tests/ColorTests/FunctionalTest/CMakeLists.txt
@@ -9,8 +9,4 @@ target_link_libraries(color_ft PRIVATE
     gtest::gtest
     azure::aziotsharedutil)
 
-# Color functional tests do not currently work on Linux so we will not run
-# them.
-if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-    k4a_add_tests(TARGET color_ft HARDWARE_REQUIRED TEST_TYPE FUNCTIONAL)
-endif()
+k4a_add_tests(TARGET color_ft HARDWARE_REQUIRED TEST_TYPE FUNCTIONAL)


### PR DESCRIPTION
## Fixes #334 

### Description of the changes:
- Add color_ft as a functional test for platforms (removed Windows only if)

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [x] Linux
