### PR TITLE
Set SONAME to libk4a.so.MAJOR_VER

### DIFF
--- a/src/record/sdk/CMakeLists.txt
+++ b/src/record/sdk/CMakeLists.txt
@@ -52,7 +52,7 @@ set_target_properties(
     k4arecord
     PROPERTIES
         VERSION ${K4A_VERSION}
-        SOVERSION ${K4A_VERSION})
+        SOVERSION ${K4A_VERSION_MAJOR})
 
 # Setup install
 include(GNUInstallDirs)

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -63,7 +63,7 @@ set_target_properties(
     k4a
     PROPERTIES
         VERSION ${K4A_VERSION}
-        SOVERSION ${K4A_VERSION})
+        SOVERSION ${K4A_VERSION_MAJOR})
 
 
 # Setup install

--- a/tests/UnitTests/dynlib_ut/CMakeLists.txt
+++ b/tests/UnitTests/dynlib_ut/CMakeLists.txt
@@ -25,7 +25,7 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
             VERSION
                 "${TEST_LIBRARY_MAJOR_VER}.${TEST_LIBRARY_MINOR_VER}"
             SOVERSION
-                "${TEST_LIBRARY_MAJOR_VER}.${TEST_LIBRARY_MINOR_VER}")
+                "${TEST_LIBRARY_MAJOR_VER}")
 endif()
 
 target_link_libraries(dynlib_ut PRIVATE


### PR DESCRIPTION
## Fixes #351

### Description of the changes:
- Changes SONAME to only include K4A_VERSION_MAJOR

### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on:
- [ ] Windows
- [x] Linux

