### PR TITLE
Remove use of NAMELINK_COMPONENT

### DIFF
--- a/src/record/sdk/CMakeLists.txt
+++ b/src/record/sdk/CMakeLists.txt
@@ -68,8 +68,7 @@ install(
             ${CMAKE_INSTALL_LIBDIR}
         COMPONENT
             runtime
-        NAMELINK_COMPONENT
-            development
+        NAMELINK_SKIP
     ARCHIVE
         DESTINATION
             ${CMAKE_INSTALL_LIBDIR}

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -78,8 +78,7 @@ install(
             ${CMAKE_INSTALL_LIBDIR}
         COMPONENT
             runtime
-        NAMELINK_COMPONENT
-            development
+        NAMELINK_SKIP
     ARCHIVE
         DESTINATION
             ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
## Fixes #371 

### Description of the changes:
- Replaces the use of NAMELINK_COMPONENT in install commands in CMakeLists.txt with NAMELINK_SKIP
- Fixes compatability with CMake 3.10

### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [x] Linux

