### PR TITLE
k4a_device_start_cameras should use const k4a_device_configuration_t

### DIFF
--- a/include/k4a/k4a.h
+++ b/include/k4a/k4a.h
@@ -1220,7 +1220,7 @@ K4A_EXPORT void k4a_image_release(k4a_image_t image_handle);
  * </requirements>
  * \endxmlonly
  */
-K4A_EXPORT k4a_result_t k4a_device_start_cameras(k4a_device_t device_handle, k4a_device_configuration_t *config);
+K4A_EXPORT k4a_result_t k4a_device_start_cameras(k4a_device_t device_handle, const k4a_device_configuration_t *config);
 
 /** Stops the color and depth camera capture.
  *

--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -996,7 +996,7 @@ public:
      *
      * \sa k4a_device_start_cameras
      */
-    void start_cameras(k4a_device_configuration_t *configuration)
+    void start_cameras(const k4a_device_configuration_t *configuration)
     {
         k4a_result_t result = k4a_device_start_cameras(m_handle, configuration);
         if (K4A_RESULT_SUCCEEDED != result)

--- a/include/k4ainternal/capturesync.h
+++ b/include/k4ainternal/capturesync.h
@@ -58,7 +58,7 @@ void capturesync_destroy(capturesync_t capturesync_handle);
  * \remarks
  * Enables the capturesync to enable its queues and begin synchronizing depth and color frames
  */
-k4a_result_t capturesync_start(capturesync_t capturesync_handle, k4a_device_configuration_t *config);
+k4a_result_t capturesync_start(capturesync_t capturesync_handle, const k4a_device_configuration_t *config);
 
 /** Prepares the capturesync object to stop synchronizing color and depth captures
  *

--- a/include/k4ainternal/color_mcu.h
+++ b/include/k4ainternal/color_mcu.h
@@ -101,7 +101,7 @@ void colormcu_destroy(colormcu_t colormcu_handle);
  *
  * \return K4A_RESULT_SUCCEEDED if the call succeeded
  */
-k4a_result_t colormcu_set_multi_device_mode(colormcu_t colormcu_handle, k4a_device_configuration_t *config);
+k4a_result_t colormcu_set_multi_device_mode(colormcu_t colormcu_handle, const k4a_device_configuration_t *config);
 
 /** Writes the device synchronization settings
  *

--- a/src/capturesync/capturesync.c
+++ b/src/capturesync/capturesync.c
@@ -475,7 +475,7 @@ void capturesync_destroy(capturesync_t capturesync_handle)
     capturesync_t_destroy(capturesync_handle);
 }
 
-k4a_result_t capturesync_start(capturesync_t capturesync_handle, k4a_device_configuration_t *config)
+k4a_result_t capturesync_start(capturesync_t capturesync_handle, const k4a_device_configuration_t *config)
 {
     RETURN_VALUE_IF_HANDLE_INVALID(K4A_RESULT_FAILED, capturesync_t, capturesync_handle);
     RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, config == NULL);

--- a/src/color_mcu/color_mcu.c
+++ b/src/color_mcu/color_mcu.c
@@ -217,7 +217,7 @@ k4a_result_t colormcu_get_external_sync_jack_state(colormcu_t colormcu_handle,
  *   K4A_RESULT_FAILED       Operation failed
  *
  */
-k4a_result_t colormcu_set_multi_device_mode(colormcu_t colormcu_handle, k4a_device_configuration_t *config)
+k4a_result_t colormcu_set_multi_device_mode(colormcu_t colormcu_handle, const k4a_device_configuration_t *config)
 {
     RETURN_VALUE_IF_HANDLE_INVALID(K4A_RESULT_FAILED, colormcu_t, colormcu_handle)
     colormcu_context_t *colormcu = colormcu_t_get_context(colormcu_handle);

--- a/src/sdk/k4a.c
+++ b/src/sdk/k4a.c
@@ -522,7 +522,7 @@ void k4a_image_release(k4a_image_t image_handle)
     image_dec_ref(image_handle);
 }
 
-static k4a_result_t validate_configuration(k4a_context_t *device, k4a_device_configuration_t *config)
+static k4a_result_t validate_configuration(k4a_context_t *device, const k4a_device_configuration_t *config)
 {
     RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, config == NULL);
     RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, device == NULL);
@@ -686,7 +686,7 @@ static k4a_result_t validate_configuration(k4a_context_t *device, k4a_device_con
     return result;
 }
 
-k4a_result_t k4a_device_start_cameras(k4a_device_t device_handle, k4a_device_configuration_t *config)
+k4a_result_t k4a_device_start_cameras(k4a_device_t device_handle, const k4a_device_configuration_t *config)
 {
     RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, config == NULL);
     RETURN_VALUE_IF_HANDLE_INVALID(K4A_RESULT_FAILED, k4a_device_t, device_handle);


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #272 

### Description of the changes:
- k4a_device_start_cameras should use const k4a_device_configuration_t

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Azure Kinetic Viewer Sanity check
