### PR TITLE
 Ensure xy_tables in transformation code is 16-byte aligned

### DIFF
--- a/src/transformation/transformation.c
+++ b/src/transformation/transformation.c
@@ -347,7 +347,11 @@ static k4a_result_t transformation_allocate_xy_tables(const k4a_calibration_t *c
         return K4A_RESULT_FAILED;
     }
 
-    *buffer = malloc(xy_tables_data_size * sizeof(float));
+#ifdef _MSC_VER
+    *buffer = _aligned_malloc(xy_tables_data_size * sizeof(float), 16);
+#else
+    *buffer = aligned_alloc(16, xy_tables_data_size * sizeof(float));
+#endif
 
     if (K4A_BUFFER_RESULT_SUCCEEDED !=
         TRACE_BUFFER_CALL(transformation_init_xy_tables(calibration, camera, *buffer, &xy_tables_data_size, xy_tables)))
@@ -439,11 +443,19 @@ void transformation_destroy(k4a_transformation_t transformation_handle)
 
     if (transformation_context->memory_depth_camera_xy_tables != 0)
     {
+#ifdef _MSC_VER
+        _aligned_free(transformation_context->memory_depth_camera_xy_tables);
+#else
         free(transformation_context->memory_depth_camera_xy_tables);
+#endif
     }
     if (transformation_context->memory_color_camera_xy_tables != 0)
     {
+#ifdef _MSC_VER
+        _aligned_free(transformation_context->memory_color_camera_xy_tables);
+#else
         free(transformation_context->memory_color_camera_xy_tables);
+#endif
     }
     if (transformation_context->tewrapper)
     {

--- a/src/transformation/transformation.c
+++ b/src/transformation/transformation.c
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#ifndef _MSC_VER
+#define _ISOC11_SOURCE /* for aligned_alloc() */
+#endif
+
 #include <k4ainternal/logging.h>
 #include <k4ainternal/deloader.h>
 #include <k4ainternal/tewrapper.h>


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #318 

### Description of the changes:
- Ensure xytable in transformation API is 16-byte aligned

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Tested transformation example as well as the Azure Kinect viewer as well on both windows and linux
