### PR TITLE
Corrected spec for the libk4a symlinks

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -119,7 +119,7 @@ linux-ubuntu/x64/release/libk4a.so (symlink)                   |                
 linux-ubuntu/x64/release/libk4a.so.1.1 (symlink)               |                    |                    | :white_check_mark: |                   |
 linux-ubuntu/x64/release/libk4a.so.1.1.0                       |                    |                    | :white_check_mark: |                    |
 linux-ubuntu/x64/release/libk4arecord.so (symlink)             |                    |                    |                    | :white_check_mark: |
-linux-ubuntu/x64/release/libk4arecord.so.1.1 (symlink)         |                    |                    |                    | :white_check_mark: |
+linux-ubuntu/x64/release/libk4arecord.so.1.1 (symlink)         |                    |                    | :white_check_mark: |                    |
 linux-ubuntu/x64/release/libk4arecord.so.1.1.0                 |                    |                    | :white_check_mark: |                    |
 linux-ubuntu/tools/x64/release/AzureKinectFirmwareTool         |                    |                    |                    |                    | :white_check_mark:
 linux-ubuntu/tools/x64/release/k4arecorder                     |                    |                    |                    |                    | :white_check_mark:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -115,11 +115,11 @@ include/k4arecord/record.h                                     | :white_check_ma
 include/k4arecord/types.h                                      | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |
 linux-ubuntu/x64/release/libdepthengine.so \*                  |                    |                    | :white_check_mark: |                    |
 linux-ubuntu/x64/release/libdepthengine.so.1.0 \*              |                    |                    | :white_check_mark: |                    |
-linux-ubuntu/x64/release/libk4a.so                             |                    |                    | :white_check_mark: |                    |
-linux-ubuntu/x64/release/libk4a.so.1.1                         |                    |                    | :white_check_mark: |                    |
+linux-ubuntu/x64/release/libk4a.so (symlink)                   |                    |                    |                    | :white_check_mark: |
+linux-ubuntu/x64/release/libk4a.so.1.1 (symlink)               |                    |                    |                    | :white_check_mark: |
 linux-ubuntu/x64/release/libk4a.so.1.1.0                       |                    |                    | :white_check_mark: |                    |
-linux-ubuntu/x64/release/libk4arecord.so                       |                    |                    | :white_check_mark: |                    |
-linux-ubuntu/x64/release/libk4arecord.so.1.1                   |                    |                    | :white_check_mark: |                    |
+linux-ubuntu/x64/release/libk4arecord.so (symlink)             |                    |                    |                    | :white_check_mark: |
+linux-ubuntu/x64/release/libk4arecord.so.1.1 (symlink)         |                    |                    |                    | :white_check_mark: |
 linux-ubuntu/x64/release/libk4arecord.so.1.1.0                 |                    |                    | :white_check_mark: |                    |
 linux-ubuntu/tools/x64/release/AzureKinectFirmwareTool         |                    |                    |                    |                    | :white_check_mark:
 linux-ubuntu/tools/x64/release/k4arecorder                     |                    |                    |                    |                    | :white_check_mark:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -116,7 +116,7 @@ include/k4arecord/types.h                                      | :white_check_ma
 linux-ubuntu/x64/release/libdepthengine.so \*                  |                    |                    | :white_check_mark: |                    |
 linux-ubuntu/x64/release/libdepthengine.so.1.0 \*              |                    |                    | :white_check_mark: |                    |
 linux-ubuntu/x64/release/libk4a.so (symlink)                   |                    |                    |                    | :white_check_mark: |
-linux-ubuntu/x64/release/libk4a.so.1.1 (symlink)               |                    |                    |                    | :white_check_mark: |
+linux-ubuntu/x64/release/libk4a.so.1.1 (symlink)               |                    |                    | :white_check_mark: |                   |
 linux-ubuntu/x64/release/libk4a.so.1.1.0                       |                    |                    | :white_check_mark: |                    |
 linux-ubuntu/x64/release/libk4arecord.so (symlink)             |                    |                    |                    | :white_check_mark: |
 linux-ubuntu/x64/release/libk4arecord.so.1.1 (symlink)         |                    |                    |                    | :white_check_mark: |


### PR DESCRIPTION
These files come in the development, not runtime, packages.
