### PR TITLE
Do not limit fetch depth in CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    fetchDepth: 20
     lfs: false
     persistCredentials: true
     submodules: true
@@ -303,7 +302,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    fetchDepth: 20
     lfs: false
     persistCredentials: true
     submodules: true
@@ -381,7 +379,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    fetchDepth: 20
     lfs: false
     persistCredentials: true
     submodules: true


### PR DESCRIPTION
## Fixes #446 

### Description of the changes:
- Removes fetch depth on CI system

### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [ ] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on:
- [ ] Windows
- [ ] Linux

There was a change from git 2.21 to 2.22 that is causing our git checkout commands to fail in CI. While we determine what that change was and how to work around it, we should disable fetch depth as a quick fix.

First failed build is here: https://dev.azure.com/ms/Azure-Kinect-Sensor-SDK/_build/results?buildId=22610

Last successful build is here: https://dev.azure.com/ms/Azure-Kinect-Sensor-SDK/_build/results?buildId=22565

You can see the git verison on the Linux agent in the checkout step.

