### PR TITLE
Fix symlink in debian package

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    fetchDepth: 20
     lfs: false
     persistCredentials: true
     submodules: true
@@ -303,7 +302,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    fetchDepth: 20
     lfs: false
     persistCredentials: true
     submodules: true
@@ -381,7 +379,6 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    fetchDepth: 20
     lfs: false
     persistCredentials: true
     submodules: true

--- a/src/record/sdk/CMakeLists.txt
+++ b/src/record/sdk/CMakeLists.txt
@@ -56,6 +56,11 @@ set_target_properties(
         SOVERSION
             "${K4A_VERSION_MAJOR}.${K4A_VERSION_MINOR}")
 
+set(NAMELINK_IF_AVAILABLE)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+    set(NAMELINK_IF_AVAILABLE NAMELINK_COMPONENT development)
+endif()
+
 # Setup install
 include(GNUInstallDirs)
 install(
@@ -68,6 +73,7 @@ install(
             ${CMAKE_INSTALL_LIBDIR}
         COMPONENT
             runtime
+        ${NAMELINK_IF_AVAILABLE}
     ARCHIVE
         DESTINATION
             ${CMAKE_INSTALL_LIBDIR}

--- a/src/record/sdk/CMakeLists.txt
+++ b/src/record/sdk/CMakeLists.txt
@@ -68,7 +68,6 @@ install(
             ${CMAKE_INSTALL_LIBDIR}
         COMPONENT
             runtime
-        NAMELINK_SKIP
     ARCHIVE
         DESTINATION
             ${CMAKE_INSTALL_LIBDIR}

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -65,6 +65,10 @@ set_target_properties(
         SOVERSION
             "${K4A_VERSION_MAJOR}.${K4A_VERSION_MINOR}")
 
+set(NAMELINK_IF_AVAILABLE)
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+    set(NAMELINK_IF_AVAILABLE NAMELINK_COMPONENT development)
+endif()
 
 # Setup install
 include(GNUInstallDirs)
@@ -78,6 +82,7 @@ install(
             ${CMAKE_INSTALL_LIBDIR}
         COMPONENT
             runtime
+        ${NAMELINK_IF_AVAILABLE}
     ARCHIVE
         DESTINATION
             ${CMAKE_INSTALL_LIBDIR}

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -78,7 +78,6 @@ install(
             ${CMAKE_INSTALL_LIBDIR}
         COMPONENT
             runtime
-        NAMELINK_SKIP
     ARCHIVE
         DESTINATION
             ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
## Fixes #417

### Description of the changes:
- Our existing packaging wasn't providing the symlink to `libk4a.so`, so you couldn't easily link against it. This should allow linking with `-lk4a` again.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

