### PR TITLE
Added code based comment to address exposure mapping

### DIFF
--- a/include/k4a/k4atypes.h
+++ b/include/k4a/k4atypes.h
@@ -466,6 +466,14 @@ typedef enum
      * May be set to ::K4A_COLOR_CONTROL_MODE_AUTO or ::K4A_COLOR_CONTROL_MODE_MANUAL.
      *
      * \details
+     * The Azure Kinect supports a limited number of fixed expsore settings. When setting this, expect the exposure to
+     * be rounded up to the nearest setting. Exceptions are 1) The last value in the table is the upper limit, so a
+     * value larger than this will be overridden to the largest entry in the table. 2) The exposure time cannot be
+     * larger than the equivelent FPS. So expect 100ms exposure time to be reduced to 30ms or 33.33ms when the camera is
+     * started. The most recent copy of the table 'device_exposure_mapping' is in
+     * https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/develop/src/color/color_priv.h
+     *
+     * \details
      * Exposure time is measured in microseconds.
      */
     K4A_COLOR_CONTROL_EXPOSURE_TIME_ABSOLUTE = 0,

--- a/src/color/color_priv.h
+++ b/src/color/color_priv.h
@@ -23,10 +23,10 @@ typedef struct _color_control_cap_t
 
 typedef struct _exposure_mapping
 {
-    int exponent;
-    int exposure_usec;
-    int exposure_mapped_50Hz_usec;
-    int exposure_mapped_60Hz_usec;
+    int exponent;                  // Windows Media Foundation implementation detail
+    int exposure_usec;             // Windows Media Foundation implementation detail
+    int exposure_mapped_50Hz_usec; // Exposure when K4A_COLOR_CONTROL_POWERLINE_FREQUENCY == 50Hz
+    int exposure_mapped_60Hz_usec; // Exposure when K4A_COLOR_CONTROL_POWERLINE_FREQUENCY == 60Hz
 } color_exposure_mapping_t;
 
 #ifdef _WIN32


### PR DESCRIPTION

## Fixes #240

### Description of the changes:
- Adding comments to code to document exposure mapping

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux
