### PR TITLE
Add the current module path to the search path

### DIFF
--- a/src/dynlib/CMakeLists.txt
+++ b/src/dynlib/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
     set(DYNLIB_SRCS dynlib_windows.c)
+    set(DYNLIB_DEPENDENCIES 
+        pathcch.lib)
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     set(DYNLIB_SRCS dynlib_linux.c)
 else()
@@ -18,7 +20,8 @@ target_include_directories(k4a_dynlib PUBLIC ${K4A_PRIV_INCLUDE_DIR})
 
 target_link_libraries(k4a_dynlib PUBLIC
     k4ainternal::allocator
-    k4ainternal::logging)
+    k4ainternal::logging
+	${DYNLIB_DEPENDENCIES})
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     target_link_libraries(k4a_dynlib PUBLIC dl)

--- a/src/dynlib/dynlib_windows.c
+++ b/src/dynlib/dynlib_windows.c
@@ -126,7 +126,7 @@ k4a_result_t dynlib_create(const char *name, uint32_t major_ver, uint32_t minor_
         }
     }
 
-    if (dllDirectory != 0)
+    if (dllDirectory != NULL)
     {
         if (RemoveDllDirectory(dllDirectory) == 0)
         {

--- a/src/dynlib/dynlib_windows.c
+++ b/src/dynlib/dynlib_windows.c
@@ -68,6 +68,8 @@ static DLL_DIRECTORY_COOKIE add_current_module_to_search()
 
     fileName[0] = L'\0';
 
+    // This adds the directory of the current module (k4a.dll) to the loader's path.
+    // This will mimic how C# loads DLLs. The loader for C code only loads from the path of the current executable
     DLL_DIRECTORY_COOKIE dllDirectory = AddDllDirectory(path);
     if (dllDirectory == 0)
     {

--- a/src/dynlib/dynlib_windows.c
+++ b/src/dynlib/dynlib_windows.c
@@ -66,7 +66,7 @@ static DLL_DIRECTORY_COOKIE add_current_module_to_search()
         return NULL;
     }
 
-    fileName[0] = '\0';
+    fileName[0] = L'\0';
 
     DLL_DIRECTORY_COOKIE dllDirectory = AddDllDirectory(path);
     if (dllDirectory == 0)
@@ -113,7 +113,9 @@ k4a_result_t dynlib_create(const char *name, uint32_t major_ver, uint32_t minor_
 
     if (K4A_SUCCEEDED(result))
     {
-        dynlib->handle = LoadLibraryA(versioned_name);
+        dynlib->handle = LoadLibraryExA(versioned_name,
+                                        NULL,
+                                        LOAD_LIBRARY_SEARCH_DEFAULT_DIRS | LOAD_LIBRARY_SEARCH_USER_DIRS);
         result = (dynlib->handle != NULL) ? K4A_RESULT_SUCCEEDED : K4A_RESULT_FAILED;
 
         if (K4A_FAILED(result))

--- a/src/dynlib/dynlib_windows.c
+++ b/src/dynlib/dynlib_windows.c
@@ -10,6 +10,7 @@
 // System dependencies
 #include <windows.h>
 #include <stdio.h>
+#include <pathcch.h>
 
 #define TOSTRING(x) STRINGIFY(x)
 
@@ -40,6 +41,9 @@ static char *generate_file_name(const char *name, uint32_t major_ver, uint32_t m
 static DLL_DIRECTORY_COOKIE add_current_module_to_search()
 {
     wchar_t path[MAX_PATH];
+    //wchar_t drive[_MAX_DRIVE];
+    //wchar_t directory[_MAX_DIR];
+
     HMODULE hModule = NULL;
 
     if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCTSTR)add_current_module_to_search, &hModule) == 0)
@@ -54,19 +58,28 @@ static DLL_DIRECTORY_COOKIE add_current_module_to_search()
         return NULL;
     }
 
-    // GetModuleFileName give the full path, but AddDllDirectory requires a directory path. Remove
-    // the filename portion of this path. This should only be running in the "K4A.dll" assembly,
-    // but verify this assumption before truncating the path. If this code is used from a different
-    // file, then this needs to be modified to search for the path separators.
-    size_t length = wcslen(path);
-    wchar_t *fileName = path + (length - 7);
-    if (fileName <= path || _wcsicmp(fileName, L"k4a.DLL") != 0)
+    //// GetModuleFileName give the full path, but AddDllDirectory requires a directory path. Remove
+    //// the filename portion of this path. This should only be running in the "K4A.dll" assembly,
+    //// but verify this assumption before truncating the path. If this code is used from a different
+    //// file, then this needs to be modified to search for the path separators.
+    // size_t length = wcslen(path);
+    // wchar_t *fileName = path + (length - 7);
+    // if (fileName <= path || _wcsicmp(fileName, L"k4a.DLL") != 0)
+    //{
+    //    LOG_WARNING("The file name of the current module is not expected.", 0);
+    //    return NULL;
+    //}
+
+    // fileName[0] = L'\0';
+
+    if (PathCchRemoveFileSpec(path, sizeof(path)) != S_OK)
     {
-        LOG_WARNING("The file name of the current module is not expected.", 0);
+        LOG_WARNING("Failed to get current module file name (%d).", GetLastError());
         return NULL;
     }
 
-    fileName[0] = L'\0';
+    //_wsplitpath_s(path, drive, _MAX_DRIVE, directory, _MAX_DIR, NULL, 0, NULL, 0);
+    //_wmakepath_s(path, MAX_PATH, drive, directory, NULL, NULL);
 
     // This adds the directory of the current module (k4a.dll) to the loader's path.
     // This will mimic how C# loads DLLs. The loader for C code only loads from the path of the current executable


### PR DESCRIPTION
## Fixes #538 

### Description of the changes:
- Adding logic to add the current module path to the search path when attempting to load the depth engine.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [X] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [X] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [X] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [X] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [X] Windows
- [ ] Linux