### PR TITLE
Document details of extrinsics

### DIFF
--- a/include/k4a/k4atypes.h
+++ b/include/k4a/k4atypes.h
@@ -931,7 +931,7 @@ typedef struct _k4a_device_configuration_t
  */
 typedef struct _k4a_calibration_extrinsics_t
 {
-    float rotation[9];    /**< 3x3 Rotation matrix, row major */
+    float rotation[9];    /**< 3x3 Rotation matrix stored in row major order */
     float translation[3]; /**< Translation vector, x,y,z (in millimeters) */
 } k4a_calibration_extrinsics_t;
 

--- a/include/k4a/k4atypes.h
+++ b/include/k4a/k4atypes.h
@@ -931,8 +931,8 @@ typedef struct _k4a_device_configuration_t
  */
 typedef struct _k4a_calibration_extrinsics_t
 {
-    float rotation[9];    /**< Rotation matrix*/
-    float translation[3]; /**< Translation vector*/
+    float rotation[9];    /**< 3x3 Rotation matrix, row major */
+    float translation[3]; /**< Translation vector, x,y,z (in millimeters) */
 } k4a_calibration_extrinsics_t;
 
 /** Camera intrinsic calibration data.


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #558 

### Description of the changes:
- Document details of how rotation matrix stored
- Document details of translation vector units

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

