### PR TITLE
Fixed x86 calling conventions in C#

### DIFF
--- a/src/csharp/Examples/WPF/MainWindow.xaml.cs
+++ b/src/csharp/Examples/WPF/MainWindow.xaml.cs
@@ -64,6 +64,13 @@ namespace Microsoft.Azure.Kinect.Sensor.Examples.WPFViewer
 
                     while (this.running)
                     {
+                        if (!Environment.Is64BitProcess)
+                        {
+                            // In 32-bit the BitmapSource memory runs out quickly and we can hit OutOfMemoryException.
+                            // Force garbage collection in each loop iteration to keep memory in check.
+                            GC.Collect();
+                        }
+
                         // Wait for a capture on a thread pool thread
                         using (Capture capture = await Task.Run(() => { return device.GetCapture(); }).ConfigureAwait(true))
                         {

--- a/src/csharp/SDK/Native/NativeMethods.cs
+++ b/src/csharp/SDK/Native/NativeMethods.cs
@@ -210,13 +210,6 @@ namespace Microsoft.Azure.Kinect.Sensor
 
         [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
-        public static extern k4a_result_t k4a_set_allocator(
-            k4a_memory_allocate_cb_t allocate,
-            k4a_memory_destroy_cb_t free
-        );
-
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
-        [NativeReference]
         public static extern k4a_result_t k4a_calibration_2d_to_2d(
             [In] ref Calibration calibration,
             ref Vector2 source_point2d,

--- a/src/csharp/SDK/Native/NativeMethods.cs
+++ b/src/csharp/SDK/Native/NativeMethods.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Azure.Kinect.Sensor
 
     internal class NativeMethods
     {
+        private const CallingConvention k4aCallingConvention = CallingConvention.Cdecl;
+
         // These types are used internally by the interop dll for marshaling purposes and are not exposed
         // over the public surface of the managed dll.
 
@@ -199,7 +201,14 @@ namespace Microsoft.Azure.Kinect.Sensor
 
         #region Functions
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
+        [NativeReference]
+        public static extern k4a_result_t k4a_set_allocator(
+            k4a_memory_allocate_cb_t allocate,
+            k4a_memory_destroy_cb_t free
+        );
+
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_set_allocator(
             k4a_memory_allocate_cb_t allocate,
@@ -217,7 +226,7 @@ namespace Microsoft.Azure.Kinect.Sensor
             out Vector2 target_point2d,
             out bool valid);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_calibration_2d_to_3d(
             [In] ref Calibration calibration,
@@ -228,7 +237,7 @@ namespace Microsoft.Azure.Kinect.Sensor
             out Vector3 target_point3d,
             out bool valid);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_calibration_3d_to_2d(
             [In] ref Calibration calibration,
@@ -238,7 +247,7 @@ namespace Microsoft.Azure.Kinect.Sensor
             out Vector2 target_point2d,
             out bool valid);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_calibration_3d_to_3d(
             [In] ref Calibration calibration,
@@ -247,7 +256,7 @@ namespace Microsoft.Azure.Kinect.Sensor
             Calibration.DeviceType target_camera,
             out Vector3 target_point3d);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_calibration_get_from_raw(
             byte[] raw_calibration,
@@ -256,23 +265,23 @@ namespace Microsoft.Azure.Kinect.Sensor
             ColorResolution color_resolution,
             out Calibration calibration);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_transformation_t k4a_transformation_create([In] ref Calibration calibration);
 
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_transformation_destroy(IntPtr transformation_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_transformation_depth_image_to_color_camera(
             k4a_transformation_t transformation_handle,
             k4a_image_t depth_image,
             k4a_image_t transformed_depth_image);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_transformation_color_image_to_depth_camera(
             k4a_transformation_t transformation_handle,
@@ -280,7 +289,7 @@ namespace Microsoft.Azure.Kinect.Sensor
             k4a_image_t color_image,
             k4a_image_t transformed_color_image);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_transformation_depth_image_to_point_cloud(
                 k4a_transformation_t transformation_handle,
@@ -288,56 +297,55 @@ namespace Microsoft.Azure.Kinect.Sensor
                 Calibration.DeviceType camera,
                 k4a_image_t xyz_image);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_device_close(IntPtr device_handle);
 
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_capture_create(out k4a_capture_t capture_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_image_t k4a_capture_get_color_image(k4a_capture_t capture_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_image_t k4a_capture_get_depth_image(k4a_capture_t capture_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_image_t k4a_capture_get_ir_image(k4a_capture_t capture_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern float k4a_capture_get_temperature_c(k4a_capture_t capture_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_capture_set_color_image(k4a_capture_t capture_handle, k4a_image_t image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_capture_set_depth_image(k4a_capture_t capture_handle, k4a_image_t image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_capture_set_ir_image(k4a_capture_t capture_handle, k4a_image_t image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_capture_set_temperature_c(k4a_capture_t capture_handle, float temperature_c);
-               
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_capture_reference(IntPtr capture_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_capture_release(IntPtr capture_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_image_create(ImageFormat format,
             int width_pixels,
@@ -345,10 +353,13 @@ namespace Microsoft.Azure.Kinect.Sensor
             int stride_bytes,
             out k4a_image_t image_handle);
 
+        [UnmanagedFunctionPointer(k4aCallingConvention)]
         public delegate IntPtr k4a_memory_allocate_cb_t(int size, out IntPtr context);
+
+        [UnmanagedFunctionPointer(k4aCallingConvention)]
         public delegate void k4a_memory_destroy_cb_t(IntPtr buffer, IntPtr context);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_image_create_from_buffer(
             ImageFormat format,
@@ -362,19 +373,19 @@ namespace Microsoft.Azure.Kinect.Sensor
             out k4a_image_t image_handle
         );
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_image_reference(IntPtr image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_image_release(IntPtr image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern UInt32 k4a_device_get_installed_count();
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_device_get_calibration(
             k4a_device_t device_handle,
@@ -383,134 +394,135 @@ namespace Microsoft.Azure.Kinect.Sensor
             out Calibration calibration);
 
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_wait_result_t k4a_device_get_capture(
             k4a_device_t device_handle,
             out k4a_capture_t capture_handle,
             Int32 timeout_in_ms);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_wait_result_t k4a_device_get_imu_sample(
             k4a_device_t device_handle,
             ImuSample imu_sample,
             Int32 timeout_in_ms);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_device_get_sync_jack(
             k4a_device_t device_handle,
             out bool sync_in_jack_connected,
             out bool sync_out_jack_connected);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_device_get_version(
             k4a_device_t device_handle,
             out k4a_hardware_version_t version);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_buffer_result_t k4a_device_get_raw_calibration(k4a_device_t device_handle, [Out] byte[] data, ref UIntPtr data_size);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_device_set_color_control(k4a_device_t device_handle, ColorControlCommand command, ColorControlMode mode, Int32 value);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_device_get_color_control(k4a_device_t device_handle, ColorControlCommand command, out ColorControlMode mode, out Int32 value);
 
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_device_start_cameras(k4a_device_t device_handle, [In] ref k4a_device_configuration_t config);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_device_stop_cameras(k4a_device_t device_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_device_start_imu(k4a_device_t device_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_device_stop_imu(k4a_device_t device_handle);
 
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_device_open(UInt32 index, out k4a_device_t device_handle);
 
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention, CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
         [NativeReference]
         public static extern k4a_buffer_result_t k4a_device_get_serialnum(k4a_device_t device_handle, StringBuilder serial_number, ref UIntPtr data_size);
 
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern UInt64 k4a_image_get_exposure_usec(k4a_image_t image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_image_set_exposure_time_usec(k4a_image_t image_handle, UInt64 value);
 
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern ImageFormat k4a_image_get_format(k4a_image_t image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern int k4a_image_get_height_pixels(k4a_image_t image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern int k4a_image_get_width_pixels(k4a_image_t image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern int k4a_image_get_stride_bytes(k4a_image_t image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern UIntPtr k4a_image_get_size(k4a_image_t image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern UInt32 k4a_image_get_iso_speed(k4a_image_t image_handle);
 
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_image_set_iso_speed(k4a_image_t image_handle, UInt32 value);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern UInt32 k4a_image_get_white_balance(k4a_image_t image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_image_set_white_balance(k4a_image_t image_handle, UInt32 value);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern UInt64 k4a_image_get_timestamp_usec(k4a_image_t image_handle);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern void k4a_image_set_timestamp_usec(k4a_image_t image_handle, UInt64 value);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern IntPtr k4a_image_get_buffer(k4a_image_t image_handle);
 
+        [UnmanagedFunctionPointer(k4aCallingConvention)]
         public delegate void k4a_logging_message_cb_t(IntPtr context, LogLevel level, [MarshalAs(UnmanagedType.LPStr)] string file, int line, [MarshalAs(UnmanagedType.LPStr)] string message);
 
-        [DllImport("k4a", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("k4a", CallingConvention = k4aCallingConvention)]
         [NativeReference]
         public static extern k4a_result_t k4a_set_debug_message_handler(
             k4a_logging_message_cb_t message_cb,

--- a/src/csharp/Tests/StubGenerator/NativeMethods.cs
+++ b/src/csharp/Tests/StubGenerator/NativeMethods.cs
@@ -7,10 +7,12 @@ namespace Microsoft.Azure.Kinect.Sensor.Test.StubGenerator
 {
     static class NativeMethods
     {
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        private const CallingConvention stubCallingConvention = CallingConvention.Cdecl;
+
+        [UnmanagedFunctionPointer(stubCallingConvention, CharSet = CharSet.Ansi)]
         public delegate void RaiseError([MarshalAs(UnmanagedType.LPStr)]string szFile, int line, [MarshalAs(UnmanagedType.LPStr)]string expression);
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Ansi)]
+        [UnmanagedFunctionPointer(stubCallingConvention, CharSet = CharSet.Ansi)]
         public delegate void Stub_SetErrorFunction(RaiseError errorFunction);
 
         [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Ansi)]
@@ -22,10 +24,10 @@ namespace Microsoft.Azure.Kinect.Sensor.Test.StubGenerator
         [DllImport("kernel32", CharSet = CharSet.Ansi, ExactSpelling = true, SetLastError = true)]
         public static extern IntPtr GetProcAddress(IntPtr hModule, string procName);
 
-        [DllImport("k4a", CharSet = CharSet.Ansi)]
+        [DllImport("k4a", CharSet = CharSet.Ansi, CallingConvention=stubCallingConvention)]
         public static extern int Stub_RegisterRedirect(string functionName, IntPtr implementation);
 
-        [DllImport("k4a", CharSet = CharSet.Ansi)]
+        [DllImport("k4a", CharSet = CharSet.Ansi, CallingConvention=stubCallingConvention)]
         public static extern int Stub_GetCallCount(string functionName);
 
         


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #574 

### Description of the changes:
- Corrected calling convention on callback delegates.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [X] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [X] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [X] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [X] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [X] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

