### PR TITLE
Fix broken link in docs/building.md

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -128,7 +128,7 @@ the C# Build and Test systems to find the needed components. Therefore, you need
 configuration and build before loading the C# solution.
 
 1. Build the project with the configuration for the k4a.dll you want to build against. (e.g. x64 RelWithDebInfo)
-2. Open the [k4a.sln](../src/csharp/k4a.sln) solution
+2. Open the [K4a.sln](../src/csharp/K4a.sln) solution
 3. Build C# from within Visual Studio
 
 **NOTE:** Running a configure step again, such as opening the folder in Visual Studio, will overwrite the settings and can break the C# build.


### PR DESCRIPTION
Fix broken link in [docs/building.md#L131](https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md#L131).

<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #

### Description of the changes:
- Fix broken link in [docs/building.md#L131](https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md#L131).  
  It is difference between lower-case (k4a.sln) and upper-case (K4a.sln) in first character.  
  It doesn't problem on local, but it can't follow links on GitHub (404 is displayed).  

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [ ] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

