### PR TITLE
Add a capture::handle() function to k4a.hpp

### DIFF
--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -503,6 +503,13 @@ public:
         return m_handle != nullptr;
     }
 
+    /** Returns the underlying k4a_capture_t handle
+     */
+    k4a_capture_t handle() const noexcept
+    {
+        return m_handle;
+    }
+
     /** Releases the underlying k4a_capture_t; the capture is set to invalid.
      */
     void reset() noexcept

--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -182,10 +182,10 @@ public:
     }
 
     /** Returns the underlying k4a_image_t handle
-     * 
+     *
      * Note that this function does not increment the reference count on the k4a_image_t.
-     * The caller is responsible for incrementing the reference count on 
-     * the k4a_image_t if the caller needs the k4a_image_t to outlive this C++ object. 
+     * The caller is responsible for incrementing the reference count on
+     * the k4a_image_t if the caller needs the k4a_image_t to outlive this C++ object.
      * Otherwise, the k4a_image_t will be destroyed by this C++ object.
      */
     k4a_image_t handle() const noexcept
@@ -509,10 +509,10 @@ public:
     }
 
     /** Returns the underlying k4a_capture_t handle
-     * 
+     *
      * Note that this function does not increment the reference count on the k4a_capture_t.
-     * The caller is responsible for incrementing the reference count on 
-     * the k4a_capture_t if the caller needs the k4a_capture_t to outlive this C++ object. 
+     * The caller is responsible for incrementing the reference count on
+     * the k4a_capture_t if the caller needs the k4a_capture_t to outlive this C++ object.
      * Otherwise, the k4a_capture_t will be destroyed by this C++ object.
      */
     k4a_capture_t handle() const noexcept

--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -182,6 +182,11 @@ public:
     }
 
     /** Returns the underlying k4a_image_t handle
+     * 
+     * Note that this function does not increment the reference count on the k4a_image_t.
+     * The caller is responsible for incrementing the reference count on 
+     * the k4a_image_t if the caller needs the k4a_image_t to outlive this C++ object. 
+     * Otherwise, the k4a_image_t will be destroyed by this C++ object.
      */
     k4a_image_t handle() const noexcept
     {
@@ -504,6 +509,11 @@ public:
     }
 
     /** Returns the underlying k4a_capture_t handle
+     * 
+     * Note that this function does not increment the reference count on the k4a_capture_t.
+     * The caller is responsible for incrementing the reference count on 
+     * the k4a_capture_t if the caller needs the k4a_capture_t to outlive this C++ object. 
+     * Otherwise, the k4a_capture_t will be destroyed by this C++ object.
      */
     k4a_capture_t handle() const noexcept
     {


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #416

### Description of the changes:
- Adds a `capture::handle()` method to the C++ wrapper, allowing access to the underlying k4a_capture_t when using the C++ wrapper. This is needed to allow the C++ wrapper and the Body Tracking SDK to work together

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Changes tested manually by compiling the Azure Kinect ROS Driver project with the changes, and accessing a k4a_capture_t handle using the new method.
