### PR TITLE
Add default timeout argument

### DIFF
--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -1126,7 +1126,7 @@ public:
         *cap = capture(capture_handle);
         return true;
     }
-    
+
     /** Reads a sensor capture into cap.  Returns true if a capture was read, false if the read timed out.
      * Throws error on failure. This API assumes an inifinate timeout.
      *
@@ -1136,7 +1136,7 @@ public:
     {
         return get_capture(cap, std::chrono::milliseconds(K4A_WAIT_INFINITE));
     }
-    
+
     /** Reads an IMU sample.  Returns true if a sample was read, false if the read timed out.
      * Throws error on failure.
      *
@@ -1157,7 +1157,7 @@ public:
 
         return true;
     }
-    
+
     /** Reads an IMU sample.  Returns true if a sample was read, false if the read timed out.
      * Throws error on failure. This API assumes an infinate timeout.
      *
@@ -1167,7 +1167,7 @@ public:
     {
         return get_imu_sample(imu_sample, std::chrono::milliseconds(K4A_WAIT_INFINITE));
     }
-    
+
     /** Starts the K4A device's cameras
      * Throws error on failure.
      *

--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -1109,7 +1109,7 @@ public:
      *
      * \sa k4a_device_get_capture
      */
-    bool get_capture(capture *cap, std::chrono::milliseconds timeout)
+    bool get_capture(capture *cap, std::chrono::milliseconds timeout = std::chrono::milliseconds(K4A_WAIT_INFINITE))
     {
         k4a_capture_t capture_handle = nullptr;
         int32_t timeout_ms = internal::clamp_cast<int32_t>(timeout.count());
@@ -1132,7 +1132,8 @@ public:
      *
      * \sa k4a_device_get_imu_sample
      */
-    bool get_imu_sample(k4a_imu_sample_t *imu_sample, std::chrono::milliseconds timeout)
+    bool get_imu_sample(k4a_imu_sample_t *imu_sample,
+                        std::chrono::milliseconds timeout = std::chrono::milliseconds(K4A_WAIT_INFINITE))
     {
         int32_t timeout_ms = internal::clamp_cast<int32_t>(timeout.count());
         k4a_wait_result_t result = k4a_device_get_imu_sample(m_handle, imu_sample, timeout_ms);

--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -1109,7 +1109,7 @@ public:
      *
      * \sa k4a_device_get_capture
      */
-    bool get_capture(capture *cap, std::chrono::milliseconds timeout = std::chrono::milliseconds(K4A_WAIT_INFINITE))
+    bool get_capture(capture *cap, std::chrono::milliseconds timeout)
     {
         k4a_capture_t capture_handle = nullptr;
         int32_t timeout_ms = internal::clamp_cast<int32_t>(timeout.count());
@@ -1126,14 +1126,23 @@ public:
         *cap = capture(capture_handle);
         return true;
     }
-
+    
+    /** Reads a sensor capture into cap.  Returns true if a capture was read, false if the read timed out.
+     * Throws error on failure. This API assumes an inifinate timeout.
+     *
+     * \sa k4a_device_get_capture
+     */
+    bool get_capture(capture *cap)
+    {
+        return get_capture(cap, std::chrono::milliseconds(K4A_WAIT_INFINITE));
+    }
+    
     /** Reads an IMU sample.  Returns true if a sample was read, false if the read timed out.
      * Throws error on failure.
      *
      * \sa k4a_device_get_imu_sample
      */
-    bool get_imu_sample(k4a_imu_sample_t *imu_sample,
-                        std::chrono::milliseconds timeout = std::chrono::milliseconds(K4A_WAIT_INFINITE))
+    bool get_imu_sample(k4a_imu_sample_t *imu_sample, std::chrono::milliseconds timeout)
     {
         int32_t timeout_ms = internal::clamp_cast<int32_t>(timeout.count());
         k4a_wait_result_t result = k4a_device_get_imu_sample(m_handle, imu_sample, timeout_ms);
@@ -1148,7 +1157,17 @@ public:
 
         return true;
     }
-
+    
+    /** Reads an IMU sample.  Returns true if a sample was read, false if the read timed out.
+     * Throws error on failure. This API assumes an infinate timeout.
+     *
+     * \sa k4a_device_get_imu_sample
+     */
+    bool get_imu_sample(k4a_imu_sample_t *imu_sample)
+    {
+        return get_imu_sample(imu_sample, std::chrono::milliseconds(K4A_WAIT_INFINITE));
+    }
+    
     /** Starts the K4A device's cameras
      * Throws error on failure.
      *


### PR DESCRIPTION
This pull request will add default timeout argument to C++ wrapper (k4a/k4a.hpp).
In many use cases, timeout will specify <code>K4A_WAIT_INFINITE</code>.
Please read this proposal #632.

## Fixes #632

### Description of the changes:
- Add default timeout argument

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

