### PR TITLE
Enables SourceLink for Windows Builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ project(K4A LANGUAGES C CXX
 
 option(K4A_BUILD_DOCS "Build K4A doxygen documentation" OFF)
 option(K4A_MTE_VERSION "Skip FW version check" OFF)
+option(K4A_SOURCE_LINK "Enable source linking on MSVC" OFF)
 
 include(GitCommands)
 
@@ -55,10 +56,30 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
-# For code, link against the static crt on windows
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+    # Link against the static crt
     include(MSVCStaticCrt)
+
+    # Turn off incremental linking
     include(MSVCLinkerFlags)
+
+    # Enable source linking
+    # NOTE: Dependencies are not properly setup here.
+    #       Currently, CMake does not know to re-link if SOURCE_LINK_JSON changes
+    #       Currently, CMake does not re-generate SOURCE_LINK_JSON if git's HEAD changes
+    if (K4A_SOURCE_LINK)
+        if ("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER_EQUAL "19.20")
+            include(SourceLink)
+            file(TO_NATIVE_PATH "${PROJECT_BINARY_DIR}/source_link.json" SOURCE_LINK_JSON)
+            source_link(${PROJECT_SOURCE_DIR} ${SOURCE_LINK_JSON})
+            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /SOURCELINK:${SOURCE_LINK_JSON}")
+            set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SOURCELINK:${SOURCE_LINK_JSON}")
+        else()
+            message(WARNING "Disabling SourceLink due to old version of MSVC. Please update to VS2019!")
+        endif()
+    endif()
+
+    # Include hashes of source files in the PDB
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /ZH:SHA_256")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /ZH:SHA_256")
 endif()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -235,7 +235,7 @@ jobs:
 
   - script: |
       set PATH=%PATH%;$(Build.BinariesDirectory)\nasmexe\nasm-2.14.02
-      cmake -G "$(BuildGenerator)" "-DCMAKE_VERBOSE_MAKEFILE=ON" "$(Build.SourcesDirectory)" "-DCMAKE_BUILD_TYPE=$(CMakeConfiguration)"
+      cmake -G "$(BuildGenerator)" "-DCMAKE_VERBOSE_MAKEFILE=ON" "$(Build.SourcesDirectory)" "-DCMAKE_BUILD_TYPE=$(CMakeConfiguration)" "-DK4A_SOURCE_LINK=ON"
     workingDirectory: '$(Build.BinariesDirectory)'
     displayName: 'CMake Configure'
     env:

--- a/cmake/GitCommands.cmake
+++ b/cmake/GitCommands.cmake
@@ -20,7 +20,68 @@ function(get_git_dir DIRECTORY OUTPUT_VAR)
         OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
-    if (GIT_DIR_OUTPUT)
-        set(${OUTPUT_VAR} ${GIT_DIR_OUTPUT} PARENT_SCOPE)
+    # Allow to fail
+    set(${OUTPUT_VAR} ${GIT_DIR_OUTPUT} PARENT_SCOPE)
+endfunction()
+
+function(get_git_current_hash DIRECTORY OUTPUT_VAR)
+    execute_process(
+        COMMAND
+            ${GIT_EXECUTABLE} rev-parse --verify HEAD
+        WORKING_DIRECTORY
+            ${DIRECTORY}
+        RESULT_VARIABLE
+            GIT_CURRENT_HASH_RESULT
+        OUTPUT_VARIABLE
+            GIT_CURRENT_HASH_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    if (NOT ("${GIT_CURRENT_HASH_RESULT}" STREQUAL "0"))
+        message(${GIT_CURRENT_HASH_OUTPUT})
+        message(FATAL_ERROR "Failed to get ${DIRECTORY} git hash")
     endif()
+
+    set(${OUTPUT_VAR} ${GIT_CURRENT_HASH_OUTPUT} PARENT_SCOPE)
+endfunction()
+
+function(get_git_remote_url DIRECTORY OUTPUT_VAR)
+    execute_process(
+        COMMAND
+            ${GIT_EXECUTABLE} config --get remote.origin.url
+        RESULT_VARIABLE
+            GIT_REMOTE_URL_RESULT
+        OUTPUT_VARIABLE
+            GIT_REMOTE_URL_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        WORKING_DIRECTORY
+            ${DIRECTORY}
+    )
+
+    if (NOT ("${GIT_REMOTE_URL_RESULT}" STREQUAL "0"))
+        message(${GIT_REMOTE_URL_OUTPUT})
+        message(FATAL_ERROR "Failed to get ${DIRECTORY} git remote")
+    endif()
+
+    set(${OUTPUT_VAR} ${GIT_REMOTE_URL_OUTPUT} PARENT_SCOPE)
+endfunction()
+
+function(run_git_submodule_foreach CMD DIRECTORY OUTPUT_VALUE)
+    execute_process(
+        COMMAND
+            ${GIT_EXECUTABLE} submodule foreach --quiet --recursive "${CMD}"
+        RESULT_VARIABLE
+            GIT_SUBMODULE_CMD_RESULT
+        OUTPUT_VARIABLE
+            GIT_SUBMODULE_CMD_OUTPUT
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        WORKING_DIRECTORY
+            ${DIRECTORY}
+    )
+
+    if (NOT ("${GIT_SUBMODULE_CMD_RESULT}" STREQUAL "0"))
+        message(${GIT_SUBMODULE_CMD_OUTPUT})
+        message(FATAL_ERROR "Failed to run git submodule foreach command: ${CMD} in ${DIRECTORY}")
+    endif()
+    set(${OUTPUT_VALUE} ${GIT_SUBMODULE_CMD_OUTPUT} PARENT_SCOPE)
 endfunction()

--- a/cmake/SourceLink.cmake
+++ b/cmake/SourceLink.cmake
@@ -1,0 +1,109 @@
+# CMake Module to generate Source Link JSON for the MSVC compiler
+#
+# Microsoft defines Source Link as the following:
+#
+# > Source Link is a developer productivity feature that allows unique
+# > information about an assembly's original source code to be embedded in its
+# > PDB during compilation.
+# https://github.com/dotnet/designs/blob/master/accepted/diagnostics/source-link.md
+#
+# Specifically, this script will embedded information into the PDB of where to
+# download the source code from. This will allow developers to use the PDB without
+# the source located on disk.
+#
+# This script currently only works with GitHub but could be extended to support
+# other source control servers. Any server which hosts their code as raw source
+# over HTTP should work.
+#
+include(GitCommands)
+
+# Warn if this is included and the compilier doesn't support source link
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+    if ("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER_EQUAL "19.20")
+        # Good to go!
+    elseif("${CMAKE_C_COMPILER_VERSION}" VERSION_GREATER_EQUAL "19.14")
+        message(STATUS "SourceLink enabled but case insensative")
+    else()
+        message(WARNING "SourceLink will not work on version of MSVC less than 19.14")
+    endif()
+else()
+    message(WARNING "SourceLink will not work on the ${CMAKE_C_COMPILER_ID} compiler")
+endif()
+
+# REPO_ROOT is the path to the repository where code it stored.
+#
+# SOURCE_LINK_JSON_PATH is the file to output the json
+function(source_link REPO_ROOT SOURCE_LINK_JSON_PATH)
+    if (NOT (IS_DIRECTORY ${REPO_ROOT}))
+        message(FATAL_ERROR "\"${REPO_ROOT}\" is not a directory")
+    endif()
+
+    get_git_remote_url(${REPO_ROOT} GIT_REMOTE)
+    get_git_current_hash(${REPO_ROOT} GIT_CURRENT_HASH)
+
+    build_source_link_rule(${REPO_ROOT} ${GIT_REMOTE} ${GIT_CURRENT_HASH} ROOT_RULE)
+
+    set(SOURCE_LINK_RULES)
+    list(APPEND SOURCE_LINK_RULES ${ROOT_RULE})
+
+    # Also build rules for submodules
+    run_git_submodule_foreach("echo $displaypath,$sha1,`git config --get remote.origin.url`" ${REPO_ROOT} SUBMODULE_INFO)
+
+    if (NOT ("${SUBMODULE_INFO}" STREQUAL ""))
+        # Turn output of new lines into a CMake list
+        string(REPLACE "\r\n" ";" SUBMODULE_INFO ${SUBMODULE_INFO})
+        string(REPLACE "\n" ";" SUBMODULE_INFO ${SUBMODULE_INFO})
+
+        foreach(ITEM ${SUBMODULE_INFO})
+            # Turn each line into a list of path;hash;url
+            string(REPLACE "," ";" SUBMODULE ${ITEM})
+            list(GET SUBMODULE 0 LOCAL_PATH)
+            list(GET SUBMODULE 1 CURRENT_HASH)
+            list(GET SUBMODULE 2 REMOTE)
+            string(CONCAT LOCAL_PATH "${REPO_ROOT}/" ${LOCAL_PATH})
+            build_source_link_rule(${LOCAL_PATH} ${REMOTE} ${CURRENT_HASH} RULE)
+            list(APPEND SOURCE_LINK_RULES ${RULE})
+        endforeach()
+    endif()
+
+    set(OUTPUT)
+    string(APPEND OUTPUT "{\n")
+    string(APPEND OUTPUT "\"documents\": {\n")
+    string(JOIN ",\n" EXPANDED_RULES ${SOURCE_LINK_RULES})
+    string(APPEND OUTPUT "${EXPANDED_RULES}\n")
+    string(APPEND OUTPUT "}\n")
+    string(APPEND OUTPUT "}\n")
+
+    file(WRITE ${SOURCE_LINK_JSON_PATH} ${OUTPUT})
+
+endfunction()
+
+function(build_source_link_rule LOCAL_PATH GIT_REMOTE GIT_CURRENT_HASH OUTPUT)
+    # Verify local path exists
+    if (NOT (IS_DIRECTORY ${LOCAL_PATH}))
+        message(FATAL_ERROR "${LOCAL_PATH} is not a directory")
+    endif()
+
+    # Change local path to native path
+    file(TO_NATIVE_PATH "${LOCAL_PATH}/*" LOCAL_PATH)
+    # Escape any backslashes for JSON
+    string(REPLACE "\\" "\\\\" LOCAL_PATH ${LOCAL_PATH})
+
+    # Verify this is a GitHub URL
+    # In the future we could support other source servers but currently they
+    # are not supported
+    if (NOT ("${GIT_REMOTE}" MATCHES "https://github\\.com"))
+        message(STATUS "Unable to sourcelink remote: \"${GIT_REMOTE}\". Unknown host")
+        return()
+    endif()
+
+    string(REPLACE ".git" "" RAW_GIT_URL ${GIT_REMOTE})
+    string(REPLACE "github.com" "raw.githubusercontent.com" RAW_GIT_URL ${RAW_GIT_URL})
+    string(CONCAT RAW_GIT_URL ${RAW_GIT_URL} "/${GIT_CURRENT_HASH}/*")
+
+    set(${OUTPUT} "\"${LOCAL_PATH}\" : \"${RAW_GIT_URL}\"" PARENT_SCOPE)
+
+endfunction(build_source_link_rule)
+
+
+


### PR DESCRIPTION
## Helps #32

### Description of the changes:

Turns on source linking for VS2019 builds

Source linking is a new way to index sources in PDBs. It embeded a JSON into the PDB which tells the debugger where to find the source files. Note, this only works in VS2019 because of file case issues in VS2017. Therefore issue #32 will not be resolved until we start shipping binaries from VS2019.

### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on:
- [ ] Windows
- [ ] Linux


To manually test this, I built a PDB with these flags off the develop branch. Then I deleted all my sources and tried to debug a unit test in VS2019. VS2019 was able to download the sources from GitHub.

Note: Source linking does not appear to work in WinDBG. I have an internal ask out about that.

