### PR TITLE
Csharp version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,9 @@ else()
 
 endif()
 
+# Generate .NET Version file.
+configure_file(VersionInfo.cs.in ${CMAKE_CURRENT_SOURCE_DIR}/src/csharp/VersionInfo.cs)
+
 set(TARGET_ARCH ${CMAKE_SYSTEM_PROCESSOR})
 
 # CMake doesn't set the target processor correctly for MSVC

--- a/VersionInfo.cs.in
+++ b/VersionInfo.cs.in
@@ -25,5 +25,5 @@ using System.Reflection;
 
 // This is the shared assembly version file for all of our assemblies.
 [assembly: AssemblyVersion("@K4A_VERSION_MAJOR@.@K4A_VERSION_MINOR@.@K4A_VERSION_PATCH@.0")]
-[assembly: AssemblyFileVersion("@VERSION_STR@")]
-[assembly: AssemblyInformationalVersion("@VERSION_STR@")]
+[assembly: AssemblyFileVersion("@VERSION_STR@.@K4A_VERSION_REVISION@")]
+[assembly: AssemblyInformationalVersion("@VERSION_STR@.@K4A_VERSION_REVISION@")]

--- a/VersionInfo.cs.in
+++ b/VersionInfo.cs.in
@@ -16,14 +16,14 @@ using System.Reflection;
 [assembly: AssemblyConfiguration("Release")]
 #endif
 
-[assembly: AssemblyProduct("Azure Kinect")]
-[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("@K4A_PRODUCTNAME@")]
+[assembly: AssemblyCompany("@K4A_COMPANYNAME@")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 
 [assembly: CLSCompliant(true)]
 
 // This is the shared assembly version file for all of our assemblies.
-[assembly: AssemblyVersion("1.2.0")]
-[assembly: AssemblyFileVersion("1.2.0-Beta.5")]
-[assembly: AssemblyInformationalVersion("1.2.0-Informational")]
+[assembly: AssemblyVersion("@K4A_VERSION_MAJOR@.@K4A_VERSION_MINOR@.@K4A_VERSION_PATCH@.0")]
+[assembly: AssemblyFileVersion("@VERSION_STR@")]
+[assembly: AssemblyInformationalVersion("@VERSION_STR@")]

--- a/src/csharp/.gitignore
+++ b/src/csharp/.gitignore
@@ -1,9 +1,9 @@
 ## Ignore CMake generated files that enable the CSharp solution to find and interact with the CMake built files.
 
 /k4a.*.props
-
-/StubGenerator.*.json
 /StubGenerator.*.xml
+
+/VersionInfo.cs
 
 ## Ignore the generated documentation file
 /SDK/Microsoft.Azure.Kinect.Sensor.xml

--- a/src/csharp/Examples/WPF/Properties/AssemblyInfo.cs
+++ b/src/csharp/Examples/WPF/Properties/AssemblyInfo.cs
@@ -13,7 +13,6 @@ using System.Windows;
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor.Examples.WPFViewer")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyProduct("Microsoft.Azure.Kinect.Sensor.Examples.WPFViewer")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components. If you need to access a type in this assembly from

--- a/src/csharp/Examples/WinForms/Properties/AssemblyInfo.cs
+++ b/src/csharp/Examples/WinForms/Properties/AssemblyInfo.cs
@@ -13,7 +13,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor.Examples.WinForms")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyProduct("Microsoft.Azure.Kinect.Sensor.Examples.WinForms")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components. If you need to access a type in this assembly from

--- a/src/csharp/Extensions/WPF/Properties/AssemblyInfo.cs
+++ b/src/csharp/Extensions/WPF/Properties/AssemblyInfo.cs
@@ -13,7 +13,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor.WPF")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyProduct("Microsoft.Azure.Kinect.Sensor.WPF")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/csharp/Extensions/WinForms/Properties/AssemblyInfo.cs
+++ b/src/csharp/Extensions/WinForms/Properties/AssemblyInfo.cs
@@ -13,7 +13,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor.WinForms")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyProduct("Microsoft.Azure.Kinect.Sensor.WinForms")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/csharp/K4a.sln
+++ b/src/csharp/K4a.sln
@@ -28,7 +28,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Files", "Solution Files", "{118BF8E1-C662-4852-955F-22DC68BB95CC}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.gitignore = .gitignore
 		AzureKinectSensorSDK.ruleset = AzureKinectSensorSDK.ruleset
+		k4a.props = k4a.props
 		Microsoft.Azure.Kinect.Sensor.snk = Microsoft.Azure.Kinect.Sensor.snk
 		stylecop.json = stylecop.json
 		VersionInfo.cs = VersionInfo.cs

--- a/src/csharp/SDK/Microsoft.Azure.Kinect.Sensor.csproj
+++ b/src/csharp/SDK/Microsoft.Azure.Kinect.Sensor.csproj
@@ -20,6 +20,10 @@
       <Link>stylecop.json</Link>
     </AdditionalFiles>  
   </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Include="..\VersionInfo.cs" Link="Properties\VersionInfo.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">

--- a/src/csharp/SDK/Microsoft.Azure.Kinect.Sensor.csproj
+++ b/src/csharp/SDK/Microsoft.Azure.Kinect.Sensor.csproj
@@ -13,6 +13,8 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(OutputPath)Microsoft.Azure.Kinect.Sensor.xml</DocumentationFile>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\Microsoft.Azure.Kinect.Sensor.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/csharp/SDK/Microsoft.Azure.Kinect.Sensor.csproj
+++ b/src/csharp/SDK/Microsoft.Azure.Kinect.Sensor.csproj
@@ -13,14 +13,6 @@
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(OutputPath)Microsoft.Azure.Kinect.Sensor.xml</DocumentationFile>
-    <Description>Microsoft Azure Kinect Sensor SDK</Description>
-    <Company>Microsoft</Company>
-    <Copyright>Copyright (c) Microsoft Corporation. All rights reserved.</Copyright>
-    <PackageLicenseExpression>Licensed under the MIT License.</PackageLicenseExpression>
-    <AssemblyVersion>1.0.0.0</AssemblyVersion>
-    <FileVersion>1.0.0.0</FileVersion>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\Microsoft.Azure.Kinect.Sensor.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
+++ b/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
@@ -28,6 +28,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\VersionInfo.cs" Link="Properties\VersionInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/csharp/Tests/FunctionalTests/Properties/AssemblyInfo.cs
+++ b/src/csharp/Tests/FunctionalTests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor")]
+[assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor.FunctionalTests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCulture("")]
 
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("28E47B37-B205-4353-92B1-1345C47CD710")]
+[assembly: Guid("ebf80b3b-83a1-4369-954b-922d8ee5e9cc")]

--- a/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
+++ b/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
@@ -54,6 +54,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\VersionInfo.cs" Link="Properties\VersionInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/csharp/Tests/StubGenerator.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/csharp/Tests/StubGenerator.UnitTests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor")]
+[assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCulture("")]
 
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("28E47B37-B205-4353-92B1-1345C47CD710")]
+[assembly: Guid("151f9524-9cf0-419d-81b7-cf2d52f90ee5")]

--- a/src/csharp/Tests/StubGenerator/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.csproj
+++ b/src/csharp/Tests/StubGenerator/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.csproj
@@ -30,6 +30,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\VersionInfo.cs" Link="Properties\VersionInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/csharp/Tests/StubGenerator/Properties/AssemblyInfo.cs
+++ b/src/csharp/Tests/StubGenerator/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor")]
+[assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor.Test.StubGenerator")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCulture("")]
 
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("28E47B37-B205-4353-92B1-1345C47CD710")]
+[assembly: Guid("44795fa0-9b17-40fb-8c8b-f77d754970c8")]

--- a/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
+++ b/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
@@ -54,6 +54,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\VersionInfo.cs" Link="Properties\VersionInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/csharp/Tests/UnitTests/Properties/AssemblyInfo.cs
+++ b/src/csharp/Tests/UnitTests/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor")]
+[assembly: AssemblyTitle("Microsoft.Azure.Kinect.Sensor.UnitTests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyCulture("")]
 
@@ -20,4 +20,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("28E47B37-B205-4353-92B1-1345C47CD710")]
+[assembly: Guid("9a8ec674-aad4-486b-b747-d53989bc8f89")]

--- a/src/csharp/VersionInfo.cs
+++ b/src/csharp/VersionInfo.cs
@@ -10,7 +10,13 @@ using System.Reflection;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyConfiguration("")]
+#if DEBUG
+[assembly: AssemblyConfiguration("Debug")]
+#else
+[assembly: AssemblyConfiguration("Release")]
+#endif
+
+[assembly: AssemblyProduct("Azure Kinect")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
@@ -18,5 +24,6 @@ using System.Reflection;
 [assembly: CLSCompliant(true)]
 
 // This is the shared assembly version file for all of our assemblies.
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.2.0")]
+[assembly: AssemblyFileVersion("1.2.0-Beta.5")]
+[assembly: AssemblyInformationalVersion("1.2.0-Informational")]

--- a/src/csharp/k4a.props
+++ b/src/csharp/k4a.props
@@ -16,11 +16,12 @@
 
   <PropertyGroup Condition="'$(BaseOutputPath)' == ''">
     <!-- This should happen if we failed to find the Azure Kinect properties file for the given platform. 
-	  This will also happen if the platform is AnyCPU and the output path wasn't included. -->
+    This will also happen if the platform is AnyCPU and the output path wasn't included. -->
     <BaseOutputPath>$(MSBuildThisFileDirectory)\Build\$(Configuration)\$(Platform)\</BaseOutputPath>
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- Prevent .NET Core and .NET Standard projects from generating assembly info from the project.-->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 </Project>

--- a/src/csharp/k4a.props
+++ b/src/csharp/k4a.props
@@ -13,24 +13,14 @@
     <BaseIntermediateOutputPath>$(K4aBinaryDirectory)\obj\</BaseIntermediateOutputPath>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\$(Platform)\$(AssemblyName)\</IntermediateOutputPath>-->
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(BaseOutputPath)' == ''">
     <!-- This should happen if we failed to find the Azure Kinect properties file for the given platform. 
-	This will also happen if the platform is AnyCPU and the output path wasn't included. -->
+	  This will also happen if the platform is AnyCPU and the output path wasn't included. -->
     <BaseOutputPath>$(MSBuildThisFileDirectory)\Build\$(Configuration)\$(Platform)\</BaseOutputPath>
   </PropertyGroup>
-  
+
   <PropertyGroup>
-    <Description>Microsoft Azure Kinect Sensor SDK</Description>
-    <Company>Microsoft</Company>
-    <Authors>Microsoft</Authors>
-    <Product>Azure Kinect</Product>
-    <Copyright>Copyright (c) Microsoft Corporation. All rights reserved.</Copyright>
-    <PackageLicenseExpression>Licensed under the MIT License.</PackageLicenseExpression>
-    <!-- This is the "Product version", which is the version of this file and just a string. See  AssemblyFileVersion. -->
-    <Version>1.2.3.4</Version>
-    <AssemblyVersion>2.3.4.5</AssemblyVersion>
-    <!-- This is the "File version", which is the identifying version of the assembly. See AssemblyVersion. -->
-    <FileVersion>3.3.4.5</FileVersion>    
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 </Project>

--- a/src/csharp/k4a.props
+++ b/src/csharp/k4a.props
@@ -19,4 +19,18 @@
 	This will also happen if the platform is AnyCPU and the output path wasn't included. -->
     <BaseOutputPath>$(MSBuildThisFileDirectory)\Build\$(Configuration)\$(Platform)\</BaseOutputPath>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <Description>Microsoft Azure Kinect Sensor SDK</Description>
+    <Company>Microsoft</Company>
+    <Authors>Microsoft</Authors>
+    <Product>Azure Kinect</Product>
+    <Copyright>Copyright (c) Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageLicenseExpression>Licensed under the MIT License.</PackageLicenseExpression>
+    <!-- This is the "Product version", which is the version of this file and just a string. See  AssemblyFileVersion. -->
+    <Version>1.2.3.4</Version>
+    <AssemblyVersion>2.3.4.5</AssemblyVersion>
+    <!-- This is the "File version", which is the identifying version of the assembly. See AssemblyVersion. -->
+    <FileVersion>3.3.4.5</FileVersion>    
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Fixes #609 

### Description of the changes:
- Switch .NET Standard and .NET Core projects to using AssemblyInfo and VersionInfo.
- Generate the VersionInfo file curing the CMake configure step.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [X] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [X] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [X] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [X] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [X] Windows
- [ ] Linux