### PR TITLE
Updates cmake project version to 1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if (NOT CMAKE_PROJECT_NAME)
 endif()
 
 project(K4A LANGUAGES C CXX
-    VERSION 1.1)
+    VERSION 1.2)
 
 option(K4A_BUILD_DOCS "Build K4A doxygen documentation" OFF)
 option(K4A_MTE_VERSION "Skip FW version check" OFF)

--- a/cmake/K4AProjectVersion.cmake
+++ b/cmake/K4AProjectVersion.cmake
@@ -22,6 +22,16 @@ if (NOT VERSION_MATCH)
     message(FATAL_ERROR "Contents of VERSION_STR ('${VERSION_STR}') are not a valid version")
 endif()
 
+if (NOT ("${CMAKE_MATCH_1}" STREQUAL "${PROJECT_VERSION_MAJOR}"))
+    # You can update cmake project version in the project() command in the root CMakeLists.txt
+    message(FATAL "CMake Project Major Version \"${PROJECT_VERSION_MAJOR}\" did not match VERSION_STR major version \"${CMAKE_MATCH_1}\"")
+endif()
+
+if (NOT ("${CMAKE_MATCH_2}" STREQUAL "${PROJECT_VERSION_MINOR}"))
+    # You can update cmake project version in the project() command in the root CMakeLists.txt
+    message(FATAL "CMake Project Minor Version \"${PROJECT_VERSION_MINOR}\" did not match VERSION_STR minor version \"${CMAKE_MATCH_2}\"")
+endif()
+
 set(K4A_VERSION_MAJOR ${CMAKE_MATCH_1})
 set(K4A_VERSION_MINOR ${CMAKE_MATCH_2})
 set(K4A_VERSION_PATCH ${CMAKE_MATCH_3})
@@ -32,6 +42,7 @@ set(K4A_VERSION_STR ${VERSION_STR})
 if (NOT K4A_VERSION_REVISION)
     set(K4A_VERSION_REVISION "0")
 endif()
+
 
 set(K4A_COMPANYNAME "Microsoft")
 set(K4A_PRODUCTNAME "Azure Kinect")


### PR DESCRIPTION
## Fixes #636 

### Description of the changes:
- Changes CMake project version from 1.1 to 1.2.
- Adds logic in the validate major and minor versions match between cmake and any version string.

### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- x ] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on:
- [ ] Windows
- [ ] Linux

