### PR TITLE
Add constant to provide default configuration for k4a_device_configuration_t

### DIFF
--- a/include/k4a/k4atypes.h
+++ b/include/k4a/k4atypes.h
@@ -1257,6 +1257,27 @@ static const k4a_device_configuration_t K4A_DEVICE_CONFIG_INIT_DISABLE_ALL = { K
                                                                                0,
                                                                                false };
 
+/** Initial default configuration setting.
+ *
+ * \remarks
+ * Use this setting to initialize a \ref k4a_device_configuration_t to a default state.
+ *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4atypes.h (include k4a/k4a.h)</requirement>
+ * </requirements>
+ * \endxmlonly
+ */
+static const k4a_device_configuration_t K4A_DEVICE_CONFIG_INIT_DEFAULT = { K4A_IMAGE_FORMAT_COLOR_BGRA32,
+                                                                           K4A_COLOR_RESOLUTION_720P,
+                                                                           K4A_DEPTH_MODE_NFOV_UNBINNED,
+                                                                           K4A_FRAMES_PER_SECOND_30,
+                                                                           true,
+                                                                           0,
+                                                                           K4A_WIRED_SYNC_MODE_STANDALONE,
+                                                                           0,
+                                                                           false };
+
 /**
  * @}
  */


### PR DESCRIPTION
Add constant to provide default configuration for <code>k4a_device_configuration_t</code>.
This constant provide same settings as default settings of k4aviewer.

https://github.com/microsoft/Azure-Kinect-Sensor-SDK/blob/5fd7f25f60247c50e3be2ace492a7d28278ad1c5/tools/k4aviewer/k4aviewersettingsmanager.h#L29-L38

```cpp
// How to use this constant
k4a_device_configuration_t configuration = K4A_DEVICE_CONFIG_INIT_DEFAULT;
configuration.color_resolution = K4A_COLOR_RESOLUTION_1080P; /*If user needs, a part of config can be rewritten.*/
device.start_cameras( &configuration );
```

This idea was think out by @xthexder.
https://github.com/microsoft/Azure-Kinect-Sensor-SDK/issues/640#issuecomment-521442512

## Fixes #640

### Description of the changes:
- Add constant to provide default configuration for <code>k4a_device_configuration_t</code>.
  It is same as default settings of k4aviewer.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

