### PR TITLE
Sets default visibility of functions to hidden on Linux

### DIFF
--- a/src/record/sdk/CMakeLists.txt
+++ b/src/record/sdk/CMakeLists.txt
@@ -17,6 +17,12 @@ include(GenerateExportHeader)
 generate_export_header(k4arecord
     EXPORT_FILE_NAME "include/k4arecord/k4arecord_export.h")
 
+# Only export functions decorated to be exported (k4arecord_export.h needed for this work)
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+    target_compile_options(k4arecord PRIVATE "-fvisibility=hidden")
+    target_link_libraries(k4arecord PRIVATE "-Wl,--exclude-libs,ALL")
+endif()
+
 # Include ${CMAKE_CURRENT_BINARY_DIR}/version.rc in the target's sources
 # to embed version information
 set(K4A_FILEDESCRIPTION "Azure Kinect Recording SDK")

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -15,6 +15,12 @@ include(GenerateExportHeader)
 generate_export_header(k4a
     EXPORT_FILE_NAME "include/k4a/k4a_export.h")
 
+# Only export functions decorated to be exported (k4a_export.h needed for this work)
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+    target_compile_options(k4a PRIVATE "-fvisibility=hidden")
+    target_link_libraries(k4a PRIVATE "-Wl,--exclude-libs,ALL")
+endif()
+
 configure_file(
     "${K4A_INCLUDE_DIR}/k4a/k4aversion.h.in"
     "${CMAKE_CURRENT_BINARY_DIR}/include/k4a/k4aversion.h"


### PR DESCRIPTION
## Fixes #650 

### Description of the changes:
- Sets `-fvisibility=hidden` for GCC and Clang compilation
- Sets `-Wl,--exclude-libs,ALL` for GCC and Clang linking

### Before submitting a Pull Request:
- [X] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [X] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on:
- [ ] Windows
- [X] Linux

I tested this by comparing the output of `nm -D bin/libk4a.so` before and after this change. Before this change we were exporting functions from our internal libs and third party dependencies. After this change we only exported functions marked as K4A_EXPORT.

