### PR TITLE
Reset now succeeds if Color camera is hung

### DIFF
--- a/src/firmware/firmware.c
+++ b/src/firmware/firmware.c
@@ -162,6 +162,11 @@ k4a_result_t firmware_create(char *device_serial_number, bool resetting_device, 
         if (K4A_SUCCEEDED(result))
         {
             result = TRACE_CALL(colormcu_create(container_id, &firmware->colormcu));
+            if ((resetting_device) && K4A_FAILED(result))
+            {
+                // We only need 1 USB device to reset
+                result = K4A_RESULT_SUCCEEDED;
+            }
         }
     }
     else if (resetting_device) // Search for just the colormcu


### PR DESCRIPTION
## Fixes #665

### Description of the changes:
- Allows firmware_create to succeed if only the depth MCU is found

### I tested changes on: 
- [x] Windows
- [ ] Linux

