### PR TITLE
Improved perf of .NET samples (Reduced sample ColorResolution to R720p)

### DIFF
--- a/src/csharp/Examples/WPF/MainWindow.xaml.cs
+++ b/src/csharp/Examples/WPF/MainWindow.xaml.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Kinect.Sensor.Examples.WPFViewer
                 device.StartCameras(new DeviceConfiguration
                 {
                     ColorFormat = ImageFormat.ColorBGRA32,
-                    ColorResolution = ColorResolution.R1440p,
+                    ColorResolution = ColorResolution.R720p,
                     DepthMode = DepthMode.WFOV_2x2Binned,
                     SynchronizedImagesOnly = true,
                     CameraFPS = FPS.FPS30,

--- a/src/csharp/Examples/WinForms/Form1.cs
+++ b/src/csharp/Examples/WinForms/Form1.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Kinect.Sensor.Examples.WinForms
                 device.StartCameras(new DeviceConfiguration
                 {
                     ColorFormat = ImageFormat.ColorBGRA32,
-                    ColorResolution = ColorResolution.R1080p,
+                    ColorResolution = ColorResolution.R720p,
                     DepthMode = DepthMode.NFOV_2x2Binned,
                     SynchronizedImagesOnly = true,
                 });

--- a/src/csharp/Examples/WinForms/Form1.cs
+++ b/src/csharp/Examples/WinForms/Form1.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Kinect.Sensor.Examples.WinForms
                 device.StartCameras(new DeviceConfiguration
                 {
                     ColorFormat = ImageFormat.ColorBGRA32,
-                    ColorResolution = ColorResolution.R720p,
+                    ColorResolution = ColorResolution.R1080p,
                     DepthMode = DepthMode.NFOV_2x2Binned,
                     SynchronizedImagesOnly = true,
                 });


### PR DESCRIPTION
Reduced ColorResolution of the WPF sample to R720p to get max 30fps performance instead of 10fps. The XAML MainWindow has much less height than 720p anyway, so the higher res color frames are just wasted computing.

<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #

### Description of the changes:
-
-
-

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

