### PR TITLE
Green screen should timeout if it can not get sync'd images

### DIFF
--- a/examples/green_screen/MultiDeviceCapturer.h
+++ b/examples/green_screen/MultiDeviceCapturer.h
@@ -14,7 +14,7 @@ constexpr std::chrono::microseconds MAX_ALLOWABLE_TIME_OFFSET_ERROR_FOR_IMAGE_TI
 
 constexpr int64_t WAIT_FOR_SYNCHRONIZED_CAPTURE_TIMEOUT = 60000;
 
-static void log_lagging_time(char *lagger, k4a::capture &master, k4a::capture &sub)
+static void log_lagging_time(const char *lagger, k4a::capture &master, k4a::capture &sub)
 {
     std::cout << std::setw(6) << lagger << " lagging: mc:" << std::setw(6)
               << master.get_color_image().get_device_timestamp().count() << "us sc:" << std::setw(6)

--- a/examples/green_screen/MultiDeviceCapturer.h
+++ b/examples/green_screen/MultiDeviceCapturer.h
@@ -14,14 +14,14 @@ constexpr std::chrono::microseconds MAX_ALLOWABLE_TIME_OFFSET_ERROR_FOR_IMAGE_TI
 
 constexpr int64_t WAIT_FOR_SYNCHRONIZED_CAPTURE_TIMEOUT = 60000;
 
-void log_lagging_time(char *lagger, k4a::capture &master, k4a::capture &sub)
+static void log_lagging_time(char *lagger, k4a::capture &master, k4a::capture &sub)
 {
     std::cout << std::setw(6) << lagger << " lagging: mc:" << std::setw(6)
               << master.get_color_image().get_device_timestamp().count() << "us sc:" << std::setw(6)
               << sub.get_color_image().get_device_timestamp().count() << "us\n";
 }
 
-void log_synced_image_time(k4a::capture &master, k4a::capture &sub)
+static void log_synced_image_time(k4a::capture &master, k4a::capture &sub)
 {
     std::cout << "Sync'd capture: mc:" << std::setw(6) << master.get_color_image().get_device_timestamp().count()
               << "us sc:" << std::setw(6) << sub.get_color_image().get_device_timestamp().count() << "us\n";

--- a/examples/green_screen/MultiDeviceCapturer.h
+++ b/examples/green_screen/MultiDeviceCapturer.h
@@ -4,12 +4,25 @@
 
 #include <chrono>
 #include <vector>
+#include <iomanip> // std::setw
 #include <k4a/k4a.hpp>
 
 // This is the maximum difference between when we expected an image's timestamp to be and when it actually occurred.
 // TODO waiting on a firmware update to be returned to 50
 constexpr std::chrono::microseconds MAX_ALLOWABLE_TIME_OFFSET_ERROR_FOR_IMAGE_TIMESTAMP(33000);
 // constexpr std::chrono::microseconds MAX_ALLOWABLE_TIME_OFFSET_ERROR_FOR_IMAGE_TIMESTAMP(50);
+
+constexpr int64_t WAIT_FOR_SYNCHRONIZED_CAPTURE_TIMEOUT = 60000;
+
+#define LOG_LAGGING_TIME(lagger)                                                                                       \
+    std::cout << std::setw(6) << lagger << " lagging: mc:" << std::setw(6)                                             \
+              << captures[0].get_color_image().get_device_timestamp().count() << "us sc:" << std::setw(6)              \
+              << captures[i + 1].get_color_image().get_device_timestamp().count() << "us\n"
+
+#define LOG_SYNCED_IMAGE_TIME()                                                                                        \
+    std::cout << "Sync'd capture: mc:" << std::setw(6) << captures[0].get_color_image().get_device_timestamp().count() \
+              << "us sc:" << std::setw(6) << captures[i + 1].get_color_image().get_device_timestamp().count()          \
+              << "us\n"
 
 class MultiDeviceCapturer
 {
@@ -20,7 +33,8 @@ public:
         bool master_found = false;
         if (device_indices.size() == 0)
         {
-            throw std::runtime_error("Capturer must be passed at least one camera!");
+            cerr << "Capturer must be passed at least one camera!\n ";
+            exit(1);
         }
         for (uint32_t i : device_indices)
         {
@@ -44,11 +58,13 @@ public:
             }
             else if (!next_device.is_sync_in_connected() && !next_device.is_sync_out_connected())
             {
-                throw std::runtime_error("Each device must have sync in or sync out connected!");
+                cerr << "Each device must have sync in or sync out connected!\n ";
+                exit(1);
             }
             else if (!next_device.is_sync_in_connected())
             {
-                throw std::runtime_error("Non-master camera found that doesn't have the sync in port connected!");
+                cerr << "Non-master camera found that doesn't have the sync in port connected!\n ";
+                exit(1);
             }
             else
             {
@@ -57,7 +73,8 @@ public:
         }
         if (!master_found)
         {
-            throw std::runtime_error("No device with sync out connected found!");
+            cerr << "No device with sync out connected found!\n ";
+            exit(1);
         }
     }
 
@@ -113,8 +130,18 @@ public:
         }
 
         bool have_synced_images = false;
+        std::chrono::system_clock::time_point start = std::chrono::system_clock::now();
         while (!have_synced_images)
         {
+            // Timeout if this is taking too long
+            int64_t duration_ms =
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - start).count();
+            if (duration_ms > WAIT_FOR_SYNCHRONIZED_CAPTURE_TIMEOUT)
+            {
+                cerr << "ERROR: Timedout waiting for synchronized captures\n";
+                exit(1);
+            }
+
             k4a::image master_color_image = captures[0].get_color_image();
             std::chrono::microseconds master_color_image_time = master_color_image.get_device_timestamp();
 
@@ -152,7 +179,7 @@ public:
                         // error: 1 - 3 = -2, which is less than the worst-case-allowable offset of -1
                         // the subordinate camera image timestamp was earlier than it is allowed to be. This means the
                         // subordinate is lagging and we need to update the subordinate to get the subordinate caught up
-                        std::cout << "Subordinate lagging...\n";
+                        LOG_LAGGING_TIME("sub");
                         subordinate_devices[i].get_capture(&captures[i + 1],
                                                            std::chrono::milliseconds{ K4A_WAIT_INFINITE });
                         break;
@@ -166,7 +193,7 @@ public:
                         // error: 3 - 1 = 2, which is more than the worst-case-allowable offset of 1
                         // the subordinate camera image timestamp was later than it is allowed to be. This means the
                         // subordinate is ahead and we need to update the master to get the master caught up
-                        std::cout << "Master lagging...\n";
+                        LOG_LAGGING_TIME("master");
                         master_device.get_capture(&captures[0], std::chrono::milliseconds{ K4A_WAIT_INFINITE });
                         break;
                     }
@@ -176,6 +203,7 @@ public:
                         // synchronized.
                         if (i == subordinate_devices.size() - 1)
                         {
+                            LOG_SYNCED_IMAGE_TIME();
                             have_synced_images = true; // now we'll finish the for loop and then exit the while loop
                         }
                     }
@@ -209,7 +237,8 @@ public:
         // devices[0] is the master. There are only devices.size() - 1 others. So, indices greater or equal are invalid
         if (i >= subordinate_devices.size())
         {
-            throw std::runtime_error("Subordinate index too large!");
+            cerr << "Subordinate index too large!\n ";
+            exit(1);
         }
         return subordinate_devices[i];
     }

--- a/examples/green_screen/main.cpp
+++ b/examples/green_screen/main.cpp
@@ -13,6 +13,7 @@
 #include <opencv2/imgproc.hpp>
 #include <opencv2/highgui.hpp>
 
+using std::cerr;
 using std::cout;
 using std::endl;
 using std::vector;
@@ -78,14 +79,17 @@ int main(int argc, char **argv)
                 "[powerline-frequency-mode (default 2 for 60 Hz)] [calibration-timeout-sec (default 60)]"
                 "[greenscreen-duration-sec (default infinity- run forever)]"
              << endl;
-        throw std::runtime_error("Not enough arguments!");
+
+        cerr << "Not enough arguments!\n";
+        exit(1);
     }
     else
     {
         num_devices = static_cast<size_t>(atoi(argv[1]));
         if (num_devices > k4a::device::get_installed_count())
         {
-            throw(std::runtime_error("Not enough cameras plugged in!"));
+            cerr << "Not enough cameras plugged in!\n";
+            exit(1);
         }
         chessboard_pattern.height = atoi(argv[2]);
         chessboard_pattern.width = atoi(argv[3]);
@@ -115,7 +119,8 @@ int main(int argc, char **argv)
 
     if (num_devices != 2 && num_devices != 1)
     {
-        throw std::runtime_error("Invalid choice for number of devices!");
+        cerr << "Invalid choice for number of devices!\n";
+        exit(1);
     }
     else if (num_devices == 2)
     {
@@ -123,15 +128,18 @@ int main(int argc, char **argv)
     }
     if (chessboard_pattern.height == 0)
     {
-        throw std::runtime_error("Chessboard height is not properly set!");
+        cerr << "Chessboard height is not properly set!\n";
+        exit(1);
     }
     if (chessboard_pattern.width == 0)
     {
-        throw std::runtime_error("Chessboard height is not properly set!");
+        cerr << "Chessboard height is not properly set!\n";
+        exit(1);
     }
     if (chessboard_square_length == 0.)
     {
-        throw std::runtime_error("Chessboard square size is not properly set!");
+        cerr << "Chessboard square size is not properly set!\n";
+        exit(1);
     }
 
     cout << "Chessboard height: " << chessboard_pattern.height << ". Chessboard width: " << chessboard_pattern.width
@@ -271,8 +279,10 @@ int main(int argc, char **argv)
     }
     else
     {
-        throw std::runtime_error("Invalid number of devices!");
+        cerr << "Invalid number of devices!" << endl;
+        exit(1);
     }
+    return 0;
 }
 
 static cv::Mat color_to_opencv(const k4a::image &im)
@@ -589,7 +599,8 @@ static Transformation calibrate_devices(MultiDeviceCapturer &capturer,
                                       chessboard_square_length);
         }
     }
-    throw std::runtime_error("Calibration timed out!");
+    std::cerr << "Calibration timed out !\n ";
+    exit(1);
 }
 
 static k4a::image create_depth_image_like(const k4a::image &im)


### PR DESCRIPTION
## Fixes #719

### Description of the changes:
- Added a timeout of 60s in the event the example can not sync images
- Added debug output to furthar debug the problem
- Removed all 'throw' and replaced with exit(1) (for error)
- Added return 0 to the end of main when the app runs to completion.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

