### PR TITLE
Fix calibration to color camera matrix

### DIFF
--- a/examples/green_screen/main.cpp
+++ b/examples/green_screen/main.cpp
@@ -305,12 +305,11 @@ static cv::Mat depth_to_opencv(const k4a::image &im)
 static cv::Matx33f calibration_to_color_camera_matrix(const k4a::calibration &cal)
 {
     const k4a_calibration_intrinsic_parameters_t::_param &i = cal.color_camera_calibration.intrinsics.parameters.param;
-    cv::Matx33f camera_matrix = cv::Matx33f::zeros();
+    cv::Matx33f camera_matrix = cv::Matx33f::eye();
     camera_matrix(0, 0) = i.fx;
-    camera_matrix(1, 1) = i.fx;
+    camera_matrix(1, 1) = i.fy;
     camera_matrix(0, 2) = i.cx;
     camera_matrix(1, 2) = i.cy;
-    camera_matrix(2, 2) = 1;
     return camera_matrix;
 }
 


### PR DESCRIPTION
Fix calibration to color camera matrix, and change matrix initialize method.

### Description of the changes:
- Change matrix initialize method to cv::Mat33f::eye().  
  It initialize matrix with identity matrix. It is suitable for this case.  
  <img src="https://latex.codecogs.com/gif.latex?$$&space;\begin{bmatrix}&space;1.0f&space;&&space;0.0f&space;&&space;0.0f&space;\\\&space;0.0f&space;&&space;1.0f&space;&&space;0.0f&space;\\\&space;0.0f&space;&&space;0.0f&space;&&space;1.0f&space;\end{bmatrix}&space;$$" />
- Fix calibration to color camera matrix.  
  camera_matrix( 1, 1 ) is fy.  
  <img src="https://latex.codecogs.com/gif.latex?$$&space;\begin{bmatrix}&space;f_x&space;&&space;0&space;&&space;c_x&space;\\\&space;0&space;&&space;f_y&space;&&space;c_y&space;\\\&space;0&space;&&space;0&space;&&space;1&space;\end{bmatrix}&space;$$" />

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

