### PR TITLE
Add a device::handle() function to k4a.hpp

### DIFF
--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -1116,6 +1116,18 @@ public:
         return m_handle != nullptr;
     }
 
+    /** Returns the underlying k4a_device_t handle
+     *
+     * Note that this function does not increment the reference count on the k4a_device_t.
+     * The caller is responsible for incrementing the reference count on
+     * the k4a_device_t if the caller needs the k4a_device_t to outlive this C++ object.
+     * Otherwise, the k4a_device_t will be destroyed by this C++ object.
+     */
+    k4a_device_t handle() const noexcept
+    {
+        return m_handle;
+    }
+
     /** Closes a k4a device.
      *
      * \sa k4a_device_close

--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -1118,10 +1118,8 @@ public:
 
     /** Returns the underlying k4a_device_t handle
      *
-     * Note that this function does not increment the reference count on the k4a_device_t.
-     * The caller is responsible for incrementing the reference count on
-     * the k4a_device_t if the caller needs the k4a_device_t to outlive this C++ object.
-     * Otherwise, the k4a_device_t will be destroyed by this C++ object.
+     * Note the k4a_device_t handle does not have a reference count will be destroyed when the C++ object is destroyed.
+     * The caller is responsible for ensuring the C++ object outlives this handle.
      */
     k4a_device_t handle() const noexcept
     {


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #748

### Description of the changes:
- Adds a device::handle() method to the C++ wrapper, allowing access to the underlying k4a_device_t when using the C++ wrapper. This is needed to allow the C++ wrapper and the recording API to work together.

  Specifically, <code>k4a_record_create()</code> requests a <code>k4a_device_t</code> handle in second argument.
```cpp
k4a_record_t recording_handle = nullptr;
k4a_record_create( path, device.handle(), device_configuration, &recording_handle );
```

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

