### PR TITLE
Clean up the unused enum type

### DIFF
--- a/include/k4a/k4atypes.h
+++ b/include/k4a/k4atypes.h
@@ -681,8 +681,6 @@ typedef enum
 typedef enum
 {
     K4A_CALIBRATION_LENS_DISTORTION_MODEL_UNKNOWN = 0,   /**< Calibration model is unknown */
-    K4A_CALIBRATION_LENS_DISTORTION_MODEL_THETA,         /**< Calibration model is Theta (arctan) */
-    K4A_CALIBRATION_LENS_DISTORTION_MODEL_POLYNOMIAL_3K, /**< Calibration model Polynomial 3K */
     K4A_CALIBRATION_LENS_DISTORTION_MODEL_RATIONAL_6KT,  /**< Calibration model Rational 6KT */
     K4A_CALIBRATION_LENS_DISTORTION_MODEL_BROWN_CONRADY, /**< Calibration model Brown Conrady (compatible with OpenCV)
                                                           */

--- a/src/calibration/calibration.c
+++ b/src/calibration/calibration.c
@@ -25,9 +25,7 @@ typedef struct _INTRINSIC_TYPE_TO_STRING_MAPPER
 } intrinsic_type_to_string_mapper_t;
 
 static intrinsic_type_to_string_mapper_t intrinsic_type_mapper[] =
-    { { K4A_CALIBRATION_LENS_DISTORTION_MODEL_THETA, "CALIBRATION_LensDistortionModelTheta" },
-      { K4A_CALIBRATION_LENS_DISTORTION_MODEL_POLYNOMIAL_3K, "CALIBRATION_LensDistortionModelPolynomial3K" },
-      { K4A_CALIBRATION_LENS_DISTORTION_MODEL_RATIONAL_6KT, "CALIBRATION_LensDistortionModelRational6KT" },
+    { { K4A_CALIBRATION_LENS_DISTORTION_MODEL_RATIONAL_6KT, "CALIBRATION_LensDistortionModelRational6KT" },
       { K4A_CALIBRATION_LENS_DISTORTION_MODEL_BROWN_CONRADY, "CALIBRATION_LensDistortionModelBrownConrady" } };
 
 typedef struct _calibration_context_t

--- a/src/csharp/SDK/CalibrationModelType.cs
+++ b/src/csharp/SDK/CalibrationModelType.cs
@@ -20,18 +20,6 @@ namespace Microsoft.Azure.Kinect.Sensor
         Unknown = 0,
 
         /// <summary>
-        /// Calibration model is Theta (arctan).
-        /// </summary>
-        [Native.NativeReference("K4A_CALIBRATION_LENS_DISTORTION_MODEL_THETA")]
-        Theta,
-
-        /// <summary>
-        /// Calibration model is Polynomial 3K.
-        /// </summary>
-        [Native.NativeReference("K4A_CALIBRATION_LENS_DISTORTION_MODEL_POLYNOMIAL_3K")]
-        Polynomial3K,
-
-        /// <summary>
         /// Calibration model is Rational 6KT.
         /// </summary>
         [Native.NativeReference("K4A_CALIBRATION_LENS_DISTORTION_MODEL_RATIONAL_6KT")]


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Helps #726 

### Description of the changes:
- There are some enum values in k4a_calibration_model_type_t we never used or plan to use, remove them to avoid confusion.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

