### PR TITLE
Properly Sets default visibility of functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,13 @@ if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--build-id")
 endif()
 
+# If using clang or GCC, set default visibilty to hidden
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+    set(CMAKE_C_VISIBILITY_PRESET hidden)
+    set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
+endif()
+
 # Find all dependencies
 add_subdirectory(extern)
 

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -44,6 +44,10 @@ if ((NOT K4A_TURNED_ON_GIT_SUBMODULES_RECURSE) OR
         endif()
     endif()
 endif()
+
+# Set default policies for older CMake projects
+set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)
+
 add_subdirectory(azure_c_shared)
 add_subdirectory(cjson)
 add_subdirectory(glfw)

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 # This forces cmake to apply CMAKE_C_VISIBILITY_PRESET,
 # CMAKE_CXX_VISIBILITY_PRESET and VISIBILITY_INLINES_HIDDEN target properties
 # to all targets, not just SHARED libraries. We want this so that files
-# compiled into static libraries have the same visibility flags and those
+# compiled into static libraries have the same visibility flags as those
 # compiled into shared libraries.
 #
 # NEW is the default for this policy except when cmake_minimum_required is

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -45,7 +45,16 @@ if ((NOT K4A_TURNED_ON_GIT_SUBMODULES_RECURSE) OR
     endif()
 endif()
 
-# Set default policies for older CMake projects
+# Set default policies for CMP0063 to NEW
+#
+# This forces cmake to apply CMAKE_C_VISIBILITY_PRESET,
+# CMAKE_CXX_VISIBILITY_PRESET and VISIBILITY_INLINES_HIDDEN target properties
+# to all targets, not just SHARED libraries. We want this so that files
+# compiled into static libraries have the same visibility flags and those
+# compiled into shared libraries.
+#
+# NEW is the default for this policy except when cmake_minimum_required is
+# lower than CMake 3.3
 set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)
 
 add_subdirectory(azure_c_shared)

--- a/src/record/sdk/CMakeLists.txt
+++ b/src/record/sdk/CMakeLists.txt
@@ -17,12 +17,6 @@ include(GenerateExportHeader)
 generate_export_header(k4arecord
     EXPORT_FILE_NAME "include/k4arecord/k4arecord_export.h")
 
-# Only export functions decorated to be exported (k4arecord_export.h needed for this work)
-if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_options(k4arecord PRIVATE "-fvisibility=hidden")
-    target_link_libraries(k4arecord PRIVATE "-Wl,--exclude-libs,ALL")
-endif()
-
 # Include ${CMAKE_CURRENT_BINARY_DIR}/version.rc in the target's sources
 # to embed version information
 set(K4A_FILEDESCRIPTION "Azure Kinect Recording SDK")

--- a/src/sdk/CMakeLists.txt
+++ b/src/sdk/CMakeLists.txt
@@ -15,12 +15,6 @@ include(GenerateExportHeader)
 generate_export_header(k4a
     EXPORT_FILE_NAME "include/k4a/k4a_export.h")
 
-# Only export functions decorated to be exported (k4a_export.h needed for this work)
-if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_options(k4a PRIVATE "-fvisibility=hidden")
-    target_link_libraries(k4a PRIVATE "-Wl,--exclude-libs,ALL")
-endif()
-
 configure_file(
     "${K4A_INCLUDE_DIR}/k4a/k4aversion.h.in"
     "${CMAKE_CURRENT_BINARY_DIR}/include/k4a/k4aversion.h"

--- a/tests/UnitTests/dynlib_ut/CMakeLists.txt
+++ b/tests/UnitTests/dynlib_ut/CMakeLists.txt
@@ -3,11 +3,17 @@
 
 add_executable(dynlib_ut dynlib.cpp)
 
+
 set(TEST_LIBRARY_NAME "test_dynlib")
 set(TEST_LIBRARY_MAJOR_VER 1)
 set(TEST_LIBRARY_MINOR_VER 2)
 
 add_library(${TEST_LIBRARY_NAME} SHARED testdynlib.c)
+
+include(GenerateExportHeader)
+generate_export_header(${TEST_LIBRARY_NAME})
+
+target_include_directories(${TEST_LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 

--- a/tests/UnitTests/dynlib_ut/testdynlib.c
+++ b/tests/UnitTests/dynlib_ut/testdynlib.c
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#include "test_dynlib_export.h"
+
 #include <stdio.h>
 
 #ifndef _WIN32
@@ -8,9 +10,9 @@
 #define __cdecl
 #endif
 
-__declspec(dllexport) void __cdecl say_hello(void);
+TEST_DYNLIB_EXPORT void __cdecl say_hello(void);
 
-__declspec(dllexport) void __cdecl say_hello(void)
+TEST_DYNLIB_EXPORT void __cdecl say_hello(void)
 {
     printf("Hello!\n");
 }

--- a/tests/UnitTests/dynlib_ut/testdynlib.c
+++ b/tests/UnitTests/dynlib_ut/testdynlib.c
@@ -5,14 +5,9 @@
 
 #include <stdio.h>
 
-#ifndef _WIN32
-#define __declspec(arg)
-#define __cdecl
-#endif
+TEST_DYNLIB_EXPORT void say_hello(void);
 
-TEST_DYNLIB_EXPORT void __cdecl say_hello(void);
-
-TEST_DYNLIB_EXPORT void __cdecl say_hello(void)
+TEST_DYNLIB_EXPORT void say_hello(void)
 {
     printf("Hello!\n");
 }


### PR DESCRIPTION
## Fixes #672 

### Description of the changes:
- Properly sets visibility flags for GCC / Clang

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


I used the following command before and after this change to verify we are not longer exporting `libjpeg` functions

`nm -gC bin/libk4a.so | grep jpeg_CreateDecompress`

