### PR TITLE
Adds better logging to firmware tool on failure

### DIFF
--- a/tools/updater/main.c
+++ b/tools/updater/main.c
@@ -993,10 +993,14 @@ static k4a_result_t command_reset_device(updater_command_info_t *command_info)
         // Re-open the device to ensure it is ready.
         printf("Waiting for reset of S/N: %s to complete.\n", command_info->device_serial_number[device_index]);
         result = ensure_firmware_open(command_info, FW_OPEN_FULL_FEATURE, device_index);
-        printf("Reset of S/N: %s is complete.\n", command_info->device_serial_number[device_index]);
 
-        if (K4A_FAILED(result))
+        if (K4A_SUCCEEDED(result))
         {
+            printf("Reset of S/N: %s is complete.\n", command_info->device_serial_number[device_index]);
+        }
+        else
+        {
+            printf("Reset of S/N: %s failed.\n", command_info->device_serial_number[device_index]);
             finalCmdStatus = K4A_RESULT_FAILED;
         }
     }

--- a/tools/updater/main.c
+++ b/tools/updater/main.c
@@ -996,11 +996,11 @@ static k4a_result_t command_reset_device(updater_command_info_t *command_info)
 
         if (K4A_SUCCEEDED(result))
         {
-            printf("Reset of S/N: %s is complete.\n", command_info->device_serial_number[device_index]);
+            printf("Reset of S/N: %s completed successfully.\n", command_info->device_serial_number[device_index]);
         }
         else
         {
-            printf("Reset of S/N: %s failed.\n", command_info->device_serial_number[device_index]);
+            printf("Reset of S/N: %s failed. Device did not re-enumerate\n", command_info->device_serial_number[device_index]);
             finalCmdStatus = K4A_RESULT_FAILED;
         }
     }

--- a/tools/updater/main.c
+++ b/tools/updater/main.c
@@ -1000,7 +1000,8 @@ static k4a_result_t command_reset_device(updater_command_info_t *command_info)
         }
         else
         {
-            printf("Reset of S/N: %s failed. Device did not re-enumerate\n", command_info->device_serial_number[device_index]);
+            printf("Reset of S/N: %s failed. Device did not re-enumerate\n",
+                   command_info->device_serial_number[device_index]);
             finalCmdStatus = K4A_RESULT_FAILED;
         }
     }


### PR DESCRIPTION
## Fixes #770 

### Description of the changes:
- Adds `failed` to AzureKinectFirmwareTool on a failed reset

### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on:
- [ ] Windows
- [ ] Linux

I was not able to repro this locally so I'm relying on the CI machines to verify this works.
