### PR TITLE
Restrict MSSE flags to arch that support it

### DIFF
--- a/src/transformation/CMakeLists.txt
+++ b/src/transformation/CMakeLists.txt
@@ -17,7 +17,9 @@ target_link_libraries(k4a_transformation PUBLIC
     )
 
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
-    target_compile_options(k4a_transformation PRIVATE "-msse4.1")
+    if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "amd64.*|x86_64.*|AMD64.*|i686.*|i386.*|x86.*|amd64.*|AMD64.*")
+        target_compile_options(k4a_transformation PRIVATE "-msse4.1")
+    endif()
 endif()
 
 # Define alias for other targets to link against

--- a/src/transformation/CMakeLists.txt
+++ b/src/transformation/CMakeLists.txt
@@ -17,7 +17,7 @@ target_link_libraries(k4a_transformation PUBLIC
     )
 
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
-    if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "amd64.*|x86_64.*|AMD64.*|i686.*|i386.*|x86.*|amd64.*|AMD64.*")
+    if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "amd64.*|x86_64.*|AMD64.*|i686.*|i386.*|x86.*")
         target_compile_options(k4a_transformation PRIVATE "-msse4.1")
     endif()
 endif()


### PR DESCRIPTION
## Fixes #798 

### Description of the changes:
- Restricts `-msse4.1` flags to processors which (might) support it

### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on:
- [ ] Windows
- [ ] Linux

I built this change under Linux and made sure the `-msse4.1` flag still existed.

