### PR TITLE
Changes made to emphasize Depth Engine version and deemphasize plugin…

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ variables:
 - name: 'windows_firmware_version'
   value: '1.6.102075014'
 - name: 'NuGetPackageVersion'
-  value: '1.3.0-alpha.1'
+  value: '1.3.0-beta.1'
 - name: 'OpenCVPath'
   value: 'C:\OpenCV\Build\x64\vc14\'
 

--- a/include/k4ainternal/dynlib.h
+++ b/include/k4ainternal/dynlib.h
@@ -42,8 +42,7 @@ K4A_DECLARE_HANDLE(dynlib_t);
  * The version information should be encoded in the filename of the dynamic
  * library being loaded. This encoding will be different for Windows versus Linux. For
  * Windows the dynamic library name is "<name>_<version>_0.dll".
- * For Linux, the dynamic library name is
- * "lib<name>.so.<version>".
+ * For Linux, the dynamic library name is "lib<name>.so.<version>.0".
  *
  * \remarks
  * This function only supports relative path libraries. If you try to load an

--- a/include/k4ainternal/dynlib.h
+++ b/include/k4ainternal/dynlib.h
@@ -20,14 +20,9 @@ extern "C" {
 K4A_DECLARE_HANDLE(dynlib_t);
 
 /**
- * The maximum major version we support for loading a dynamic library
+ * The maximum version we support for loading a dynamic library
  */
-#define DYNLIB_MAX_MAJOR_VERSION 99ul
-
-/**
- * The maximum minor version we support for loading a dynamic library
- */
-#define DYNLIB_MAX_MINOR_VERSION 99ul
+#define DYNLIB_MAX_VERSION 99ul
 
 /** Loads a versioned dynamic library (shared library) by name and version.
  *  The version information is encoded in the filename.
@@ -35,13 +30,9 @@ K4A_DECLARE_HANDLE(dynlib_t);
  * \param name [IN]
  * Name of the dynamic library or shared library
  *
- * \param major_ver
- * Expected major version of the dynamic library. This number must be less than
- * or equal to \ref DYNLIB_MAX_MAJOR_VERSION.
- *
- * \param minor_ver
- * Expected minor version of the dynamic library. This number must be less than
- * or equal to \ref DYNLIB_MIN_MAJOR_VERSION.
+ * \param version
+ * Version of the plugin being used to load the dynamic library. This number must be less than
+ * or equal to \ref DYNLIB_MAX_VERSION.
  *
  * \param dynlib_handle [OUT]
  * A handle to store dynlib in. Only valid if function returns
@@ -49,10 +40,10 @@ K4A_DECLARE_HANDLE(dynlib_t);
  *
  * \remarks
  * The version information should be encoded in the filename of the dynamic
- * library. This encoding will be different for Windows versus Linux. For
- * Windows the dynamic library name is "<name>_<major_ver>_<minor_ver>.dll".
+ * library being loaded. This encoding will be different for Windows versus Linux. For
+ * Windows the dynamic library name is "<name>_<version>_0.dll".
  * For Linux, the dynamic library name is
- * "lib<name>.so.<major_ver>.<minor_ver>".
+ * "lib<name>.so.<version>".
  *
  * \remarks
  * This function only supports relative path libraries. If you try to load an
@@ -64,7 +55,7 @@ K4A_DECLARE_HANDLE(dynlib_t);
  * \return K4A_RESULT_SUCCEEDED if the library was loaded, K4A_RESULT_FAILED
  * otherwise
  */
-k4a_result_t dynlib_create(const char *name, uint32_t major_ver, uint32_t minor_ver, dynlib_t *dynlib_handle);
+k4a_result_t dynlib_create(const char *name, uint32_t version, dynlib_t *dynlib_handle);
 
 /** Finds the address of an exported symbol in a loaded dynamic library
  *

--- a/include/k4ainternal/k4aplugin.h
+++ b/include/k4ainternal/k4aplugin.h
@@ -23,10 +23,10 @@ extern "C" {
 #endif
 
 /**
- * Current Version of the Azure Kinect Depth Engine Plugin
+ * Current Version of the Azure Kinect Depth Engine Plugin Interface
  *
  * \remarks
- * When the depth engine plugin is updated this version should be increased.
+ * When the depth engine plugin interface (k4a_plugin_t) is updated, this version should be increased.
  *
  * \remarks
  * The depth version binary name has the plugin version appended to it to signify the compatibility between the plugin

--- a/include/k4ainternal/k4aplugin.h
+++ b/include/k4ainternal/k4aplugin.h
@@ -23,28 +23,16 @@ extern "C" {
 #endif
 
 /**
- * Current Version of the K4A depth engine and this Plugin interface
+ * Current Version of the Azure Kinect Depth Engine Plugin
  *
  * \remarks
- * This plugin version and the depth engine are tied together with the major.minor version. When the depth engine takes
- * a breaking change, then its major version must me increased. In turn the major version of this interface must
- * also be increased.
+ * When the depth engine plugin is updated this version should be increased.
  *
  * \remarks
- * When the depth engine takes on new features, then the minor version must be increased. Increasing the minor version
- * while keep the major version the same is not expected to be a breaking change. This in theory should allow a new
- * version of the depth engine to work with an older version of the SDK. However the SDK team does not explicitly test
- * and verify this, as a result there is no attempt to allow the sdk to work with depth engine version newer than the
- * version it was built with. Instead the plug in minor version is updated with the minor version of the depth engine.
- *
- * \remarks
- * The patch version of the depth engine is increased for bug fixes.
+ * The depth version binary name has the plugin version appended to it to signify the compatibility between the plugin
+ * and the depth engine.
  */
-#define K4A_DEPTH_ENGINE_MAJOR_VERSION 2 /**< Depth engine major version */
-#define K4A_DEPTH_ENGINE_MINOR_VERSION 1 /**< Depth engine minor version */
-
-#define K4A_PLUGIN_MAJOR_VERSION K4A_DEPTH_ENGINE_MAJOR_VERSION /**< Azure Kinect plugin major version */
-#define K4A_PLUGIN_MINOR_VERSION K4A_DEPTH_ENGINE_MINOR_VERSION /**< Azure Kinect plugin minor version */
+#define K4A_PLUGIN_VERSION 2 /**< Azure Kinect plugin version */
 
 /**
  * Expected name of plugin's dynamic library
@@ -227,7 +215,7 @@ typedef enum
 
 /** Depth Engine plugin version
  *
- * /remarks On load, k4a will validate that major versions match between the SDK
+ * /remarks On load, Azure Kinect will validate that major versions match between the SDK
  * and the plugin.
  *
  * \xmlonly
@@ -483,9 +471,9 @@ typedef void(__stdcall *k4a_te_destroy_fn_t)(k4a_transform_engine_context_t **co
 /** Plugin API which must be populated on plugin registration.
  *
  * \remarks
- * The K4A SDK will call k4a_register_plugin, and pass in a pointer to a \ref
+ * The Azure Kinect SDK will call k4a_register_plugin, and pass in a pointer to a \ref
  * k4a_plugin_t. The plugin must properly fill out all fields of the plugin for
- * the K4A SDK to accept the plugin.
+ * the Azure Kinect SDK to accept the plugin.
  *
  * \xmlonly
  * <requirements>

--- a/include/k4ainternal/k4aplugin.h
+++ b/include/k4ainternal/k4aplugin.h
@@ -23,13 +23,28 @@ extern "C" {
 #endif
 
 /**
- * Current Version of the k4A Depth Engine Plugin API
+ * Current Version of the K4A depth engine and this Plugin interface
  *
- * \remarks The MAJOR version must be updated to denote any breaking change
- * that would cause an older SDK to not be able to use this plugin.
+ * \remarks
+ * This plugin version and the depth engine are tied together with the major.minor version. When the depth engine takes
+ * a breaking change, then its major version must me increased. In turn the major version of this interface must
+ * also be increased.
+ *
+ * \remarks
+ * When the depth engine takes on new features, then the minor version must be increased. Increasing the minor version
+ * while keep the major version the same is not expected to be a breaking change. This in theory should allow a new
+ * version of the depth engine to work with an older version of the SDK. However the SDK team does not explicitly test
+ * and verify this, as a result there is no attempt to allow the sdk to work with depth engine version newer than the
+ * version it was built with. Instead the plug in minor version is updated with the minor version of the depth engine.
+ *
+ * \remarks
+ * The patch version of the depth engine is increased for bug fixes.
  */
-#define K4A_PLUGIN_MAJOR_VERSION 2 /**< Azure Kinect plugin major version */
-#define K4A_PLUGIN_MINOR_VERSION 0 /**< Azure Kinect plugin minor version */
+#define K4A_DEPTH_ENGINE_MAJOR_VERSION 2 /**< Depth engine major version */
+#define K4A_DEPTH_ENGINE_MINOR_VERSION 1 /**< Depth engine minor version */
+
+#define K4A_PLUGIN_MAJOR_VERSION K4A_DEPTH_ENGINE_MAJOR_VERSION /**< Azure Kinect plugin major version */
+#define K4A_PLUGIN_MINOR_VERSION K4A_DEPTH_ENGINE_MINOR_VERSION /**< Azure Kinect plugin minor version */
 
 /**
  * Expected name of plugin's dynamic library
@@ -51,19 +66,31 @@ extern "C" {
 
 /** Supported Depth Engine modes
  *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef enum
 {
     K4A_DEPTH_ENGINE_MODE_UNKNOWN = -1,           /**< Unknown Depth Engine mode */
-    K4A_DEPTH_ENGINE_MODE_LT_SW_BINNING = 2,      /**< Translates to ::K4A_DEPTH_MODE_NFOV_2X2BINNED */
-    K4A_DEPTH_ENGINE_MODE_PCM = 3,                /**< Translates to ::K4A_DEPTH_MODE_PASSIVE_IR */
-    K4A_DEPTH_ENGINE_MODE_LT_NATIVE = 4,          /**< Translates to ::K4A_DEPTH_MODE_NFOV_UNBINNED */
-    K4A_DEPTH_ENGINE_MODE_MEGA_PIXEL = 5,         /**< Translates to ::K4A_DEPTH_MODE_WFOV_UNBINNED */
-    K4A_DEPTH_ENGINE_MODE_QUARTER_MEGA_PIXEL = 7, /**< Translates to ::K4A_DEPTH_MODE_WFOV_2X2BINNED */
+    K4A_DEPTH_ENGINE_MODE_ST = 0,                 /**< Internal use only */
+    K4A_DEPTH_ENGINE_MODE_LT_HW_BINNING = 1,      /**< Internal use only */
+    K4A_DEPTH_ENGINE_MODE_LT_SW_BINNING = 2,      /**< Translates to K4A_DEPTH_MODE_NFOV_2X2BINNED */
+    K4A_DEPTH_ENGINE_MODE_PCM = 3,                /**< Translates to K4A_DEPTH_MODE_PASSIVE_IR */
+    K4A_DEPTH_ENGINE_MODE_LT_NATIVE = 4,          /**< Translates to K4A_DEPTH_MODE_NFOV_UNBINNED */
+    K4A_DEPTH_ENGINE_MODE_MEGA_PIXEL = 5,         /**< Translates to K4A_DEPTH_MODE_WFOV_UNBINNED */
+    K4A_DEPTH_ENGINE_MODE_QUARTER_MEGA_PIXEL = 7, /**< Translates to K4A_DEPTH_MODE_WFOV_2X2BINNED */
 } k4a_depth_engine_mode_t;
 
 /** Depth Engine output types
  *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef enum
 {
@@ -74,16 +101,28 @@ typedef enum
 
 /** Depth Engine supported input formats
  *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef enum
 {
     K4A_DEPTH_ENGINE_INPUT_TYPE_UNKNOWN = 0,          /**< Unknown Depth Engine input type */
+    K4A_DEPTH_ENGINE_INPUT_TYPE_16BIT_LINEAR = 1,     /**< Internal use only */
+    K4A_DEPTH_ENGINE_INPUT_TYPE_12BIT_RAW = 2,        /**< Internal use only */
     K4A_DEPTH_ENGINE_INPUT_TYPE_12BIT_COMPRESSED = 3, /**< 12bit compressed */
     K4A_DEPTH_ENGINE_INPUT_TYPE_8BIT_COMPRESSED = 4,  /**< 8bit compressed */
 } k4a_depth_engine_input_type_t;
 
 /** Transform Engine types
  *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef enum
 {
@@ -95,6 +134,11 @@ typedef enum
 
 /** Transform Engine interpolation type
  *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef enum
 {
@@ -104,6 +148,11 @@ typedef enum
 
 /** Depth Engine output frame information
  *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef struct _k4a_depth_engine_output_frame_info_t
 {
@@ -120,6 +169,11 @@ typedef struct _k4a_depth_engine_output_frame_info_t
  * /remarks At Runtime, please set to null, we parse these information from a
  * raw compressed input. Some internal testing may use this to pass in temperature info.
  *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef struct _k4a_depth_engine_input_frame_info_t
 {
@@ -131,6 +185,11 @@ typedef struct _k4a_depth_engine_input_frame_info_t
 
 /** Depth Engine return codes
  *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef enum
 {
@@ -171,6 +230,11 @@ typedef enum
  * /remarks On load, k4a will validate that major versions match between the SDK
  * and the plugin.
  *
+ * \xmlonly
+ * <requirements>k4a_depth
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef struct
 {
@@ -181,11 +245,21 @@ typedef struct
 
 /** Depth Engine context handle to be implemented by plugin
  *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef struct k4a_depth_engine_context_t k4a_depth_engine_context_t;
 
 /** Transform Engine context handle to be implemented by plugin
  *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef struct k4a_transform_engine_context_t k4a_transform_engine_context_t;
 
@@ -235,7 +309,7 @@ typedef void(__stdcall k4a_processing_complete_cb_t)(void *context,
  * An optional context to be passed back to the callback
  *
  * \returns
- * ::K4A_DEPTH_ENGINE_RESULT_SUCCEEDED on success, or the proper failure code on
+ * K4A_DEPTH_ENGINE_RESULT_SUCCEEDED on success, or the proper failure code on
  * failure
  */
 typedef k4a_depth_engine_result_code_t(__stdcall *k4a_de_create_and_initialize_fn_t)(
@@ -244,7 +318,7 @@ typedef k4a_depth_engine_result_code_t(__stdcall *k4a_de_create_and_initialize_f
     void *cal_block,
     k4a_depth_engine_mode_t mode,
     k4a_depth_engine_input_type_t input_format,
-    void *camera_calibration,
+    void *camera_calibration, // Fallback to use ccb intrinsics if it is null
     k4a_processing_complete_cb_t *callback,
     void *callback_context);
 
@@ -275,7 +349,7 @@ typedef k4a_depth_engine_result_code_t(__stdcall *k4a_de_create_and_initialize_f
  * The input frame information (internal use only), should pass in null at runtime
  *
  * \returns
- * ::K4A_DEPTH_ENGINE_RESULT_SUCCEEDED on success, or the proper failure code on
+ * K4A_DEPTH_ENGINE_RESULT_SUCCEEDED on success, or the proper failure code on
  * failure
  */
 typedef k4a_depth_engine_result_code_t(__stdcall *k4a_de_process_frame_fn_t)(
@@ -320,7 +394,7 @@ typedef void(__stdcall *k4a_de_destroy_fn_t)(k4a_depth_engine_context_t **contex
  * An optional context to be passed back to the callback
  *
  * \returns
- * ::K4A_DEPTH_ENGINE_RESULT_SUCCEEDED on success, or the proper failure code on
+ * K4A_DEPTH_ENGINE_RESULT_SUCCEEDED on success, or the proper failure code on
  * failure
  */
 typedef k4a_depth_engine_result_code_t(__stdcall *k4a_te_create_and_initialize_fn_t)(
@@ -368,7 +442,7 @@ typedef k4a_depth_engine_result_code_t(__stdcall *k4a_te_create_and_initialize_f
  * Size of the output_frame2 buffer in bytes
  *
  * \returns
- * ::K4A_DEPTH_ENGINE_RESULT_SUCCEEDED on success, or the proper failure code on
+ * K4A_DEPTH_ENGINE_RESULT_SUCCEEDED on success, or the proper failure code on
  * failure
  */
 typedef k4a_depth_engine_result_code_t(__stdcall *k4a_te_process_frame_fn_t)(
@@ -409,14 +483,19 @@ typedef void(__stdcall *k4a_te_destroy_fn_t)(k4a_transform_engine_context_t **co
 /** Plugin API which must be populated on plugin registration.
  *
  * \remarks
- * The Azure Kinect SDK will call k4a_register_plugin, and pass in a pointer to a \ref
+ * The K4A SDK will call k4a_register_plugin, and pass in a pointer to a \ref
  * k4a_plugin_t. The plugin must properly fill out all fields of the plugin for
- * the Azure Kinect SDK to accept the plugin.
+ * the K4A SDK to accept the plugin.
  *
+ * \xmlonly
+ * <requirements>
+ *   <requirement name="Header">k4aplugin.h (include k4a/k4aplugin.h)</requirement>
+ * </requirements>
+ * \endxmlonly
  */
 typedef struct _k4a_plugin_t
 {
-    k4a_plugin_version_t version; /**< Version this plugin was written against */
+    k4a_plugin_version_t version;                                         /**< Depth Engine Version */
     k4a_de_create_and_initialize_fn_t depth_engine_create_and_initialize; /**< Function pointer to a
                                                                              depth_engine_create_and_initialize function
                                                                            */

--- a/src/deloader/deloader.cpp
+++ b/src/deloader/deloader.cpp
@@ -50,15 +50,6 @@ static bool verify_plugin(const k4a_plugin_t *plugin)
              plugin->version.minor,
              plugin->version.patch);
 
-    // Major versions must match
-    if (plugin->version.major != K4A_PLUGIN_MAJOR_VERSION)
-    {
-        LOG_ERROR("Plugin Major Version Mismatch. Expected %u. Found %u",
-                  K4A_PLUGIN_MAJOR_VERSION,
-                  plugin->version.major);
-        return false;
-    }
-
     // All function pointers must be non NULL
     RETURN_VALUE_IF_ARG(false, plugin->depth_engine_create_and_initialize == NULL);
     RETURN_VALUE_IF_ARG(false, plugin->depth_engine_process_frame == NULL);
@@ -77,10 +68,7 @@ static void deloader_init_once(deloader_global_context_t *global)
 {
     // All members are initialized to zero
 
-    k4a_result_t result = dynlib_create(K4A_PLUGIN_DYNAMIC_LIBRARY_NAME,
-                                        K4A_PLUGIN_MAJOR_VERSION,
-                                        K4A_PLUGIN_MINOR_VERSION,
-                                        &global->handle);
+    k4a_result_t result = dynlib_create(K4A_PLUGIN_DYNAMIC_LIBRARY_NAME, K4A_PLUGIN_VERSION, &global->handle);
     if (K4A_FAILED(result))
     {
         LOG_ERROR("Failed to Load Depth Engine Plugin (%s). Depth functionality will not work",

--- a/src/deloader/deloader.cpp
+++ b/src/deloader/deloader.cpp
@@ -45,7 +45,7 @@ static bool verify_plugin(const k4a_plugin_t *plugin)
 {
     RETURN_VALUE_IF_ARG(false, plugin == NULL);
 
-    LOG_INFO("Loaded K4A Plugin with version: %u.%u.%u",
+    LOG_INFO("Loaded Depth Engine version: %u.%u.%u",
              plugin->version.major,
              plugin->version.minor,
              plugin->version.patch);

--- a/src/dynlib/dynlib_linux.c
+++ b/src/dynlib/dynlib_linux.c
@@ -26,9 +26,9 @@ static char *generate_file_name(const char *name, uint32_t version)
 {
     const char *lib_prefix = "lib";
     const char *lib_suffix = "so";
-    size_t max_buffer_size = strlen(name) + strlen(TOSTRING(DYNLIB_MAX_VERSION)) +
-                             strlen(TOSTRING(DYNLIB_MAX_MINOR_VERSION)) + strlen(".") + strlen(".") +
-                             strlen(lib_suffix) + strlen(lib_prefix) + 1;
+    // Format of the depth engine name is: libdepthengine.so.2.0
+    size_t max_buffer_size = strlen(name) + strlen(TOSTRING(DYNLIB_MAX_VERSION)) + strlen(".0") + strlen(".") +
+                             strlen(".") + strlen(lib_suffix) + strlen(lib_prefix) + 1;
 
     char *versioned_file_name = malloc(max_buffer_size);
     if (versioned_file_name == NULL)

--- a/src/dynlib/dynlib_linux.c
+++ b/src/dynlib/dynlib_linux.c
@@ -12,7 +12,6 @@
 #include <stdio.h>
 #include <ctype.h>
 #define __USE_GNU
-#define _GNU_SOURCE
 #include <dlfcn.h>
 
 #define TOSTRING(x) STRINGIFY(x)

--- a/src/dynlib/dynlib_linux.c
+++ b/src/dynlib/dynlib_linux.c
@@ -11,6 +11,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
+#define __USE_GNU
+#define _GNU_SOURCE
 #include <dlfcn.h>
 
 #define TOSTRING(x) STRINGIFY(x)
@@ -119,6 +121,19 @@ k4a_result_t dynlib_find_symbol(dynlib_t dynlib_handle, const char *symbol, void
     else
     {
         LOG_ERROR("Failed to find symbol %s in dynamic library. Error: ", symbol, dlerror());
+    }
+
+    if (K4A_SUCCEEDED(result))
+    {
+        Dl_info info;
+        if (dladdr(*address, &info) != 0)
+        {
+            LOG_INFO("Depth Engine loaded %s", info.dli_fname);
+        }
+        else
+        {
+            LOG_ERROR("Failed calling dladdr %x", dlerror());
+        }
     }
 
     return result;

--- a/src/dynlib/dynlib_linux.c
+++ b/src/dynlib/dynlib_linux.c
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#define _GNU_SOURCE // ldaddr() extention in dlfcn.h
+
 // This library
 #include <k4ainternal/dynlib.h>
 
@@ -11,7 +13,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
-#define __USE_GNU
 #include <dlfcn.h>
 
 #define TOSTRING(x) STRINGIFY(x)
@@ -26,7 +27,8 @@ static char *generate_file_name(const char *name, uint32_t version)
 {
     const char *lib_prefix = "lib";
     const char *lib_suffix = "so";
-    // Format of the depth engine name is: libdepthengine.so.2.0
+    // Format of the depth engine name is: libdepthengine.so.<K4A_PLUGIN_VERSION>.0
+    //                                     libdepthengine.so.2.0
     size_t max_buffer_size = strlen(name) + strlen(TOSTRING(DYNLIB_MAX_VERSION)) + strlen(".0") + strlen(".") +
                              strlen(".") + strlen(lib_suffix) + strlen(lib_prefix) + 1;
 

--- a/src/dynlib/dynlib_linux.c
+++ b/src/dynlib/dynlib_linux.c
@@ -22,11 +22,11 @@ typedef struct _dynlib_context_t
 } dynlib_context_t;
 
 K4A_DECLARE_CONTEXT(dynlib_t, dynlib_context_t);
-static char *generate_file_name(const char *name, uint32_t major_ver, uint32_t minor_ver)
+static char *generate_file_name(const char *name, uint32_t version)
 {
     const char *lib_prefix = "lib";
     const char *lib_suffix = "so";
-    size_t max_buffer_size = strlen(name) + strlen(TOSTRING(DYNLIB_MAX_MAJOR_VERSION)) +
+    size_t max_buffer_size = strlen(name) + strlen(TOSTRING(DYNLIB_MAX_VERSION)) +
                              strlen(TOSTRING(DYNLIB_MAX_MINOR_VERSION)) + strlen(".") + strlen(".") +
                              strlen(lib_suffix) + strlen(lib_prefix) + 1;
 
@@ -37,37 +37,30 @@ static char *generate_file_name(const char *name, uint32_t major_ver, uint32_t m
         return NULL;
     }
     versioned_file_name[0] = '\0';
-    snprintf(versioned_file_name, max_buffer_size, "%s%s.%s.%u.%u", lib_prefix, name, lib_suffix, major_ver, minor_ver);
+    // NOTE: 0 is appended to the name for legacy reasons, a time when the depth engine plugin version was tracked with
+    // major and minor versions
+    snprintf(versioned_file_name, max_buffer_size, "%s%s.%s.%u.0", lib_prefix, name, lib_suffix, version);
 
     return versioned_file_name;
 }
 
-k4a_result_t dynlib_create(const char *name, uint32_t major_ver, uint32_t minor_ver, dynlib_t *dynlib_handle)
+k4a_result_t dynlib_create(const char *name, uint32_t version, dynlib_t *dynlib_handle)
 {
     // Note: A nullptr is allowed on linux systems for "name", however, this is
     // functionality we do not support
     RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, name == NULL);
     RETURN_VALUE_IF_ARG(K4A_RESULT_FAILED, dynlib_handle == NULL);
 
-    if (major_ver > DYNLIB_MAX_MAJOR_VERSION)
+    if (version > DYNLIB_MAX_VERSION)
     {
-        LOG_ERROR("Failed to load dynamic library %s. major_ver %u is too large to load. Max is %u\n",
+        LOG_ERROR("Failed to load dynamic library %s. version %u is too large to load. Max is %u\n",
                   name,
-                  major_ver,
-                  DYNLIB_MAX_MAJOR_VERSION);
+                  version,
+                  DYNLIB_MAX_VERSION);
         return K4A_RESULT_FAILED;
     }
 
-    if (minor_ver > DYNLIB_MAX_MINOR_VERSION)
-    {
-        LOG_ERROR("Failed to load dynamic library %s. minor_ver %u is too large to load. Max is %u\n",
-                  name,
-                  minor_ver,
-                  DYNLIB_MAX_MINOR_VERSION);
-        return K4A_RESULT_FAILED;
-    }
-
-    char *versioned_name = generate_file_name(name, major_ver, minor_ver);
+    char *versioned_name = generate_file_name(name, version);
     if (versioned_name == NULL)
     {
         return K4A_RESULT_FAILED;

--- a/src/dynlib/dynlib_windows.c
+++ b/src/dynlib/dynlib_windows.c
@@ -121,6 +121,22 @@ k4a_result_t dynlib_create(const char *name, uint32_t major_ver, uint32_t minor_
         }
     }
 
+    if (dynlib->handle)
+    {
+        char file_path[MAX_PATH];
+
+        DWORD ret = GetModuleFileNameA(dynlib->handle, file_path, sizeof(file_path));
+        result = K4A_RESULT_FROM_BOOL(ret <= sizeof(file_path));
+        if (K4A_FAILED(result))
+        {
+            LOG_ERROR("Failed calling GetModuleFileNameA %x", GetLastError());
+        }
+        else
+        {
+            LOG_INFO("Depth Engine loaded %s", file_path);
+        }
+    }
+
     if (dllDirectory != NULL)
     {
         if (RemoveDllDirectory(dllDirectory) == 0)

--- a/src/dynlib/dynlib_windows.c
+++ b/src/dynlib/dynlib_windows.c
@@ -23,7 +23,8 @@ K4A_DECLARE_CONTEXT(dynlib_t, dynlib_context_t);
 
 static char *generate_file_name(const char *name, uint32_t version)
 {
-    // Format of the depth engine name is: depthengine_2_0
+    // Format of the depth engine name is: depthengine_<K4A_PLUGIN_VERSION>_0
+    //                                     depthengine_2_0
     size_t max_buffer_size = strlen(name) + strlen(TOSTRING(DYNLIB_MAX_VERSION)) + strlen("_0") + strlen("_") + 1;
 
     char *versioned_file_name = malloc(max_buffer_size);

--- a/src/dynlib/dynlib_windows.c
+++ b/src/dynlib/dynlib_windows.c
@@ -23,8 +23,8 @@ K4A_DECLARE_CONTEXT(dynlib_t, dynlib_context_t);
 
 static char *generate_file_name(const char *name, uint32_t version)
 {
-    size_t max_buffer_size = strlen(name) + strlen(TOSTRING(DYNLIB_MAX_VERSION)) + strlen(TOSTRING(0)) + strlen("_") +
-                             strlen("_") + 1;
+    // Format of the depth engine name is: depthengine_2_0
+    size_t max_buffer_size = strlen(name) + strlen(TOSTRING(DYNLIB_MAX_VERSION)) + strlen("_0") + strlen("_") + 1;
 
     char *versioned_file_name = malloc(max_buffer_size);
     if (versioned_file_name == NULL)

--- a/tests/UnitTests/dynlib_ut/CMakeLists.txt
+++ b/tests/UnitTests/dynlib_ut/CMakeLists.txt
@@ -5,8 +5,7 @@ add_executable(dynlib_ut dynlib.cpp)
 
 
 set(TEST_LIBRARY_NAME "test_dynlib")
-set(TEST_LIBRARY_MAJOR_VER 1)
-set(TEST_LIBRARY_MINOR_VER 2)
+set(TEST_LIBRARY_VERSION 1)
 
 add_library(${TEST_LIBRARY_NAME} SHARED testdynlib.c)
 
@@ -21,7 +20,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
         ${TEST_LIBRARY_NAME}
         PROPERTIES
             OUTPUT_NAME
-                "${TEST_LIBRARY_NAME}_${TEST_LIBRARY_MAJOR_VER}_${TEST_LIBRARY_MINOR_VER}")
+                "${TEST_LIBRARY_NAME}_${TEST_LIBRARY_VERSION}_0")
 
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 
@@ -29,9 +28,9 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
         ${TEST_LIBRARY_NAME}
         PROPERTIES
             VERSION
-                "${TEST_LIBRARY_MAJOR_VER}.${TEST_LIBRARY_MINOR_VER}"
+                "${TEST_LIBRARY_VERSION}.0"
             SOVERSION
-                "${TEST_LIBRARY_MAJOR_VER}")
+                "${TEST_LIBRARY_VERSION}")
 endif()
 
 target_link_libraries(dynlib_ut PRIVATE
@@ -39,8 +38,7 @@ target_link_libraries(dynlib_ut PRIVATE
     k4ainternal::dynlib
     k4ainternal::utcommon)
 
-target_compile_definitions(dynlib_ut PRIVATE TEST_LIBRARY_MAJOR_VER=${TEST_LIBRARY_MAJOR_VER})
-target_compile_definitions(dynlib_ut PRIVATE TEST_LIBRARY_MINOR_VER=${TEST_LIBRARY_MINOR_VER})
+target_compile_definitions(dynlib_ut PRIVATE TEST_LIBRARY_VERSION=${TEST_LIBRARY_VERSION})
 target_compile_definitions(dynlib_ut PRIVATE TEST_LIBRARY_NAME="${TEST_LIBRARY_NAME}")
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")

--- a/tests/UnitTests/dynlib_ut/dynlib.cpp
+++ b/tests/UnitTests/dynlib_ut/dynlib.cpp
@@ -14,8 +14,7 @@ TEST(dynlib_ut, loadk4a)
 {
     dynlib_t dynlib_handle = NULL;
 
-    ASSERT_EQ(K4A_RESULT_SUCCEEDED,
-              dynlib_create(TEST_LIBRARY_NAME, TEST_LIBRARY_MAJOR_VER, TEST_LIBRARY_MINOR_VER, &dynlib_handle));
+    ASSERT_EQ(K4A_RESULT_SUCCEEDED, dynlib_create(TEST_LIBRARY_NAME, TEST_LIBRARY_VERSION, &dynlib_handle));
 
     void *address = NULL;
     ASSERT_EQ(K4A_BUFFER_RESULT_SUCCEEDED, dynlib_find_symbol(dynlib_handle, "say_hello", &address));

--- a/tools/deversion/main.c
+++ b/tools/deversion/main.c
@@ -28,48 +28,46 @@ int main(const int argc, const char *argv[])
 
     uint32_t num_found = 0;
 
-    for (uint32_t major_ver = 0; major_ver <= K4A_PLUGIN_MAJOR_VERSION; major_ver++)
+    for (uint32_t version = 0; version <= K4A_PLUGIN_VERSION; version++)
     {
-        for (uint32_t minor_ver = 0; minor_ver <= K4A_PLUGIN_MINOR_VERSION; minor_ver++)
+        k4a_plugin_t plugin;
+        memset(&plugin, 0, sizeof(plugin));
+        dynlib_t handle;
+        memset(&handle, 0, sizeof(handle));
+
+        k4a_register_plugin_fn registerFn = NULL;
+
+        k4a_result_t result = dynlib_create(K4A_PLUGIN_DYNAMIC_LIBRARY_NAME, version, &handle);
+
+        if (K4A_SUCCEEDED(result))
         {
-            k4a_plugin_t plugin;
-            memset(&plugin, 0, sizeof(plugin));
-            dynlib_t handle;
-            memset(&handle, 0, sizeof(handle));
-
-            k4a_register_plugin_fn registerFn = NULL;
-
-            k4a_result_t result = dynlib_create(K4A_PLUGIN_DYNAMIC_LIBRARY_NAME, major_ver, minor_ver, &handle);
-
-            if (K4A_SUCCEEDED(result))
-            {
-                result = dynlib_find_symbol(handle, K4A_PLUGIN_EXPORTED_FUNCTION, (void **)&registerFn);
-            }
-            else
-            {
-                continue;
-            }
-
-            if (K4A_SUCCEEDED(result))
-            {
-                bool succeeded = registerFn(&plugin);
-                result = succeeded ? K4A_RESULT_SUCCEEDED : K4A_RESULT_FAILED;
-            }
-
-            if (K4A_SUCCEEDED(result))
-            {
-                bool current = (major_ver == K4A_PLUGIN_MAJOR_VERSION) && (minor_ver == K4A_PLUGIN_MINOR_VERSION);
-                printf("Found Depth Engine Version: %u.%u.%u%s\n",
-                       plugin.version.major,
-                       plugin.version.minor,
-                       plugin.version.patch,
-                       (current) ? " (current)" : "");
-
-                num_found++;
-            }
-
-            dynlib_destroy(handle);
+            result = dynlib_find_symbol(handle, K4A_PLUGIN_EXPORTED_FUNCTION, (void **)&registerFn);
         }
+        else
+        {
+            continue;
+        }
+
+        if (K4A_SUCCEEDED(result))
+        {
+            bool succeeded = registerFn(&plugin);
+            result = succeeded ? K4A_RESULT_SUCCEEDED : K4A_RESULT_FAILED;
+        }
+
+        if (K4A_SUCCEEDED(result))
+        {
+            bool current = (version == K4A_PLUGIN_VERSION);
+            printf("Using plugin version: %u, found Depth Engine version: %u.%u.%u%s\n",
+                   version,
+                   plugin.version.major,
+                   plugin.version.minor,
+                   plugin.version.patch,
+                   (current) ? " (current)" : "");
+
+            num_found++;
+        }
+
+        dynlib_destroy(handle);
     }
 
     if (num_found == 0)

--- a/tools/deversion/main.c
+++ b/tools/deversion/main.c
@@ -59,7 +59,7 @@ int main(const int argc, const char *argv[])
             if (K4A_SUCCEEDED(result))
             {
                 bool current = (major_ver == K4A_PLUGIN_MAJOR_VERSION) && (minor_ver == K4A_PLUGIN_MINOR_VERSION);
-                printf("Found Depth Engine Pluging Version: %u.%u.%u%s\n",
+                printf("Found Depth Engine Version: %u.%u.%u%s\n",
                        plugin.version.major,
                        plugin.version.minor,
                        plugin.version.patch,


### PR DESCRIPTION
… version. Added trace message to Windows and Linux to log path to loaded depth engine.

## Fixes #801

### Description of the changes:
- Depth Engine now reports the depth engine version rather than the plugin version.
- Changes made to emphasize Depth Engine version and deemphasize plugin version.
- Added trace message to Windows and Linux to log path to loaded depth engine.
- Also synchronized changes in k4aplugin.h between the two repro's.
