### PR TITLE
Fixing a typo in the Firmware Tests.

### DIFF
--- a/tests/FirmwareTests/firmware_helper.cpp
+++ b/tests/FirmwareTests/firmware_helper.cpp
@@ -165,20 +165,20 @@ k4a_result_t setup_common_test()
 
     std::cout << "Loading Test firmware package: " << g_test_firmware_path << std::endl;
     load_firmware_files(g_test_firmware_path, &g_test_firmware_buffer, &g_test_firmware_size);
-    g_candidate_firmware_package_info.buffer = g_candidate_firmware_buffer;
-    g_candidate_firmware_package_info.size = g_candidate_firmware_size;
+    g_test_firmware_package_info.buffer = g_test_firmware_buffer;
+    g_test_firmware_package_info.size = g_test_firmware_size;
     parse_firmware_package(&g_test_firmware_package_info);
 
     std::cout << "Loading LKG firmware package: " << g_lkg_firmware_path << std::endl;
     load_firmware_files(g_lkg_firmware_path, &g_lkg_firmware_buffer, &g_lkg_firmware_size);
-    g_candidate_firmware_package_info.buffer = g_candidate_firmware_buffer;
-    g_candidate_firmware_package_info.size = g_candidate_firmware_size;
+    g_lkg_firmware_package_info.buffer = g_lkg_firmware_buffer;
+    g_lkg_firmware_package_info.size = g_lkg_firmware_size;
     parse_firmware_package(&g_lkg_firmware_package_info);
 
     std::cout << "Loading Factory firmware package: " << g_factory_firmware_path << std::endl;
     load_firmware_files(g_factory_firmware_path, &g_factory_firmware_buffer, &g_factory_firmware_size);
-    g_candidate_firmware_package_info.buffer = g_candidate_firmware_buffer;
-    g_candidate_firmware_package_info.size = g_candidate_firmware_size;
+    g_factory_firmware_package_info.buffer = g_factory_firmware_buffer;
+    g_factory_firmware_package_info.size = g_factory_firmware_size;
     parse_firmware_package(&g_factory_firmware_package_info);
 
     common_initialized = true;


### PR DESCRIPTION
### Description of the changes:
- Fixes a typo in the Firmware Tests preventing them from loading the firmware correctly.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [X] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [X] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [X] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [X] Windows
- [ ] Linux