### PR TITLE
RUNPATH only should be set during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,9 @@ endif()
 # executable for shared objects. This is done on Linux to emulate the default
 # behavior of the Windows loader, which searches for DLLs in the path of the
 # executable.
+#
+# We only set RPATH for build since our libs and executables are put in the
+# same folder.
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     set(CMAKE_BUILD_RPATH "\$ORIGIN")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,7 @@ endif()
 # behavior of the Windows loader, which searches for DLLs in the path of the
 # executable.
 if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
-    set(CMAKE_BUILD_WITH_INSTALL_RPATH YES)
-    set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+    set(CMAKE_BUILD_RPATH "\$ORIGIN")
 endif()
 
 set(TARGET_ARCH ${CMAKE_SYSTEM_PROCESSOR})


### PR DESCRIPTION
## Helps #836 

### Description of the changes:
- Removes variables for CMake to set RPATH during install

### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on:
- [ ] Windows
- [x] Linux

I used the command `readelf -d libk4a.so | grep RUNPATH` to check RUNPATH in both the built binary and the installed binary. The built binary had a RUNPATH of `0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:]` the installed binary had nothing.

