### PR TITLE
Helper fix in undistort example

### DIFF
--- a/examples/undistort/main.cpp
+++ b/examples/undistort/main.cpp
@@ -128,7 +128,7 @@ static pinhole_t create_pinhole_from_xy_range(const k4a_calibration_t *calibrati
     }
 
     float x_min = 0, x_max = 0, y_min = 0, y_max = 0;
-    compute_xy_range(calibration, K4A_CALIBRATION_TYPE_DEPTH, width, height, x_min, x_max, y_min, y_max);
+    compute_xy_range(calibration, camera, width, height, x_min, x_max, y_min, y_max);
 
     pinhole_t pinhole;
 


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #858 

### Description of the changes:
- Simple fix of a helper in undistort to take camera type instead of just depth

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

