### PR TITLE
Set expected Locale for cJSON and calibration blob

### DIFF
--- a/src/calibration/calibration.c
+++ b/src/calibration/calibration.c
@@ -651,17 +651,12 @@ k4a_result_t calibration_create_from_raw(char *raw_calibration,
         result = K4A_RESULT_FROM_BOOL(setlocale(LC_ALL, "C") != NULL);
     }
 
-#else
+#else // NOT _WIN32
 
     locale_t thread_locale = newlocale(LC_ALL_MASK, "C", (locale_t)0);
     locale_t previous_locale = uselocale(thread_locale);
 
 #endif
-
-    if (K4A_SUCCEEDED(result))
-    {
-        setlocale(LC_ALL, "C");
-    }
 
     if (K4A_SUCCEEDED(result) && depth_calibration != NULL)
     {
@@ -695,15 +690,12 @@ k4a_result_t calibration_create_from_raw(char *raw_calibration,
             result = K4A_RESULT_FAILED;
         }
     }
-#else
-    if (previous_locale != NULL)
+#else // NOT _WIN32
+    if ((previous_locale != NULL) && (K4A_FAILED(K4A_RESULT_FROM_BOOL(uselocale(previous_locale) != NULL))))
     {
-        if (K4A_FAILED(K4A_RESULT_FROM_BOOL(uselocale(previous_locale) != NULL)))
-        {
-            // Only set result to failed, don't let this call succeed and clear a failure that might have happened
-            // already.
-            result = K4A_RESULT_FAILED;
-        }
+        // Only set result to failed, don't let this call succeed and clear a failure that might have happened
+        // already.
+        result = K4A_RESULT_FAILED;
     }
     if (thread_locale)
     {

--- a/src/calibration/calibration.c
+++ b/src/calibration/calibration.c
@@ -7,6 +7,7 @@
 // Dependent libraries
 #include <k4ainternal/common.h>
 #include <cJSON.h>
+#include <locale.h> //cJSON.h need this set correctly.
 
 // System dependencies
 #include <stdlib.h>
@@ -636,7 +637,33 @@ k4a_result_t calibration_create_from_raw(char *raw_calibration,
 
     k4a_result_t result = K4A_RESULT_SUCCEEDED;
 
-    if (depth_calibration != NULL)
+#ifdef _WIN32
+    int previous_thread_locale = -1;
+    if (K4A_SUCCEEDED(result))
+    {
+        previous_thread_locale = _configthreadlocale(_ENABLE_PER_THREAD_LOCALE);
+        result = K4A_RESULT_FROM_BOOL(previous_thread_locale == _ENABLE_PER_THREAD_LOCALE ||
+                                      previous_thread_locale == _DISABLE_PER_THREAD_LOCALE);
+    }
+
+    if (K4A_SUCCEEDED(result))
+    {
+        result = K4A_RESULT_FROM_BOOL(setlocale(LC_ALL, "C") != NULL);
+    }
+
+#else
+
+    locale_t thread_locale = newlocale(LC_ALL_MASK, "C", (locale_t)0);
+    locale_t previous_locale = uselocale(thread_locale);
+
+#endif
+
+    if (K4A_SUCCEEDED(result))
+    {
+        setlocale(LC_ALL, "C");
+    }
+
+    if (K4A_SUCCEEDED(result) && depth_calibration != NULL)
     {
         result = get_camera_calibration(raw_calibration, depth_calibration, "CALIBRATION_CameraLocationD0");
     }
@@ -657,6 +684,32 @@ k4a_result_t calibration_create_from_raw(char *raw_calibration,
                                      accel_calibration,
                                      "CALIBRATION_InertialSensorType_Accelerometer");
     }
+
+#ifdef _WIN32
+    if (previous_thread_locale == _ENABLE_PER_THREAD_LOCALE || previous_thread_locale == _DISABLE_PER_THREAD_LOCALE)
+    {
+        if (K4A_FAILED(K4A_RESULT_FROM_BOOL(_configthreadlocale(previous_thread_locale) != -1)))
+        {
+            // Only set result to failed, don't let this call succeed and clear a failure that might have happened
+            // already.
+            result = K4A_RESULT_FAILED;
+        }
+    }
+#else
+    if (previous_locale != NULL)
+    {
+        if (K4A_FAILED(K4A_RESULT_FROM_BOOL(uselocale(previous_locale) != NULL)))
+        {
+            // Only set result to failed, don't let this call succeed and clear a failure that might have happened
+            // already.
+            result = K4A_RESULT_FAILED;
+        }
+    }
+    if (thread_locale)
+    {
+        freelocale(thread_locale);
+    }
+#endif
 
     return result;
 }


### PR DESCRIPTION
## Fixes #883

### Description of the changes:
- Switching locale from process based to thread based and setting the locale based on the calibration raw data.