### PR TITLE
Allow recording BGRA color, and add warning for slow disk speeds

### DIFF
--- a/include/k4ainternal/matroska_common.h
+++ b/include/k4ainternal/matroska_common.h
@@ -81,6 +81,11 @@ constexpr uint64_t operator"" _s(unsigned long long x)
 #define CLUSTER_WRITE_DELAY_NS 2_s
 #endif
 
+#ifndef CLUSTER_WRITE_QUEUE_WARNING_NS
+// If a cluster is in the qeuue too long, warn about disk write speed.
+#define CLUSTER_WRITE_QUEUE_WARNING_NS CLUSTER_WRITE_DELAY_NS + 2_s
+#endif
+
 #ifndef CUE_ENTRY_GAP_NS
 #define CUE_ENTRY_GAP_NS 1_s
 #endif

--- a/src/record/sdk/record.cpp
+++ b/src/record/sdk/record.cpp
@@ -82,6 +82,9 @@ k4a_result_t k4a_record_create(const char *path,
             case K4A_IMAGE_FORMAT_COLOR_MJPG:
                 color_mode_str << "MJPG_" << color_height << "P";
                 break;
+            case K4A_IMAGE_FORMAT_COLOR_BGRA32:
+                color_mode_str << "BGRA_" << color_height << "P";
+                break;
             default:
                 LOG_ERROR("Unsupported color_format specified in recording: %d", device_config.color_format);
                 result = K4A_RESULT_FAILED;

--- a/tests/RecordTests/UnitTest/CMakeLists.txt
+++ b/tests/RecordTests/UnitTest/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(playback_perf playback_perf.cpp test_helpers.cpp)
 target_link_libraries(record_ut PRIVATE
     k4ainternal::utcommon
     k4ainternal::record
+    k4a::k4arecord
 )
 
 target_link_libraries(playback_ut PRIVATE

--- a/tests/RecordTests/UnitTest/playback_ut.cpp
+++ b/tests/RecordTests/UnitTest/playback_ut.cpp
@@ -987,6 +987,41 @@ TEST_F(playback_ut, open_depth_only_file)
     k4a_playback_close(handle);
 }
 
+TEST_F(playback_ut, open_bgra_color_file)
+{
+    k4a_playback_t handle = NULL;
+    k4a_result_t result = k4a_playback_open("record_test_bgra_color.mkv", &handle);
+    ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+
+    // Read recording configuration
+    k4a_record_configuration_t config;
+    result = k4a_playback_get_record_configuration(handle, &config);
+    ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+    ASSERT_EQ(config.color_format, K4A_IMAGE_FORMAT_COLOR_BGRA32);
+    ASSERT_EQ(config.color_resolution, K4A_COLOR_RESOLUTION_1080P);
+    ASSERT_EQ(config.depth_mode, K4A_DEPTH_MODE_OFF);
+    ASSERT_EQ(config.camera_fps, K4A_FRAMES_PER_SECOND_30);
+    ASSERT_TRUE(config.color_track_enabled);
+    ASSERT_FALSE(config.depth_track_enabled);
+    ASSERT_FALSE(config.ir_track_enabled);
+    ASSERT_FALSE(config.imu_track_enabled);
+    ASSERT_EQ(config.depth_delay_off_color_usec, 0);
+    ASSERT_EQ(config.wired_sync_mode, K4A_WIRED_SYNC_MODE_STANDALONE);
+    ASSERT_EQ(config.subordinate_delay_off_master_usec, (uint32_t)0);
+    ASSERT_EQ(config.start_timestamp_offset_usec, (uint32_t)0);
+
+    uint64_t timestamps[3] = { 0, 0, 0 };
+
+    k4a_capture_t capture = NULL;
+    k4a_stream_result_t stream_result = k4a_playback_get_next_capture(handle, &capture);
+    ASSERT_EQ(stream_result, K4A_STREAM_RESULT_SUCCEEDED);
+    ASSERT_TRUE(
+        validate_test_capture(capture, timestamps, config.color_format, config.color_resolution, config.depth_mode));
+    k4a_capture_release(capture);
+
+    k4a_playback_close(handle);
+}
+
 int main(int argc, char **argv)
 {
     k4a_unittest_init();

--- a/tests/RecordTests/UnitTest/record_ut.cpp
+++ b/tests/RecordTests/UnitTest/record_ut.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include <utcommon.h>
+#include <iostream>
 
 // Module being tested
 #include <k4ainternal/matroska_write.h>
@@ -131,6 +132,9 @@ TEST_F(record_ut, new_cluster_out_of_order)
     ASSERT_EQ(context->pending_clusters.size(), 3u);
 }
 
+// This test's goal is to fill up the write queue by saturating disk write.
+// It should trigger the write speed warning message in the logs.
+// Since this test is unlikely to complete, and needs to be manually run, it is disabled.
 TEST_F(record_ut, DISABLED_bgra_color_max_disk_write)
 {
     k4a_device_configuration_t record_config = {};
@@ -138,6 +142,16 @@ TEST_F(record_ut, DISABLED_bgra_color_max_disk_write)
     record_config.color_resolution = K4A_COLOR_RESOLUTION_2160P;
     record_config.depth_mode = K4A_DEPTH_MODE_OFF;
     record_config.camera_fps = K4A_FRAMES_PER_SECOND_30;
+
+    std::cout
+        << "A 'Disk write speed is too low, write queue is filling up.' log message is expected after about 4 seconds."
+        << std::endl;
+    std::cout
+        << "If the test completes without this log message, the check may be broken, or the test disk may be too fast."
+        << std::endl;
+    std::cout
+        << "If the test crashes due to an out-of-memory condition without logging a disk warning, the check is broken."
+        << std::endl;
 
     k4a_record_t handle = NULL;
     k4a_result_t result = k4a_record_create("record_test_bgra_color.mkv", NULL, record_config, &handle);

--- a/tests/RecordTests/UnitTest/record_ut.cpp
+++ b/tests/RecordTests/UnitTest/record_ut.cpp
@@ -5,6 +5,8 @@
 
 // Module being tested
 #include <k4ainternal/matroska_write.h>
+#include <k4arecord/record.h>
+#include <k4a/k4a.h>
 
 #include <ebml/MemIOCallback.h>
 #include <matroska/KaxSegment.h>
@@ -127,6 +129,68 @@ TEST_F(record_ut, new_cluster_out_of_order)
     }
 
     ASSERT_EQ(context->pending_clusters.size(), 3u);
+}
+
+TEST_F(record_ut, DISABLED_bgra_color_max_disk_write)
+{
+    k4a_device_configuration_t record_config = {};
+    record_config.color_format = K4A_IMAGE_FORMAT_COLOR_BGRA32;
+    record_config.color_resolution = K4A_COLOR_RESOLUTION_2160P;
+    record_config.depth_mode = K4A_DEPTH_MODE_OFF;
+    record_config.camera_fps = K4A_FRAMES_PER_SECOND_30;
+
+    k4a_record_t handle = NULL;
+    k4a_result_t result = k4a_record_create("record_test_bgra_color.mkv", NULL, record_config, &handle);
+    ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+
+    result = k4a_record_write_header(handle);
+    ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+
+    uint64_t timestamp_ns = 0;
+    for (int i = 0; i < 1000; i++)
+    {
+        k4a_capture_t capture = NULL;
+        result = k4a_capture_create(&capture);
+        ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+
+        uint32_t width = 3840;
+        uint32_t height = 2160;
+        uint32_t stride = width * 4;
+        size_t buffer_size = height * stride;
+        uint8_t *buffer = new uint8_t[height * stride];
+        memset(buffer, 0xFF, height * stride);
+
+        k4a_image_t color_image = NULL;
+        result = k4a_image_create_from_buffer(record_config.color_format,
+                                              (int)width,
+                                              (int)height,
+                                              (int)stride,
+                                              buffer,
+                                              buffer_size,
+                                              [](void *_buffer, void *ctx) {
+                                                  delete[](uint8_t *) _buffer;
+                                                  (void)ctx;
+                                              },
+                                              NULL,
+                                              &color_image);
+        ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+
+        k4a_image_set_device_timestamp_usec(color_image, timestamp_ns / 1000);
+        k4a_capture_set_color_image(capture, color_image);
+        k4a_image_release(color_image);
+
+        result = k4a_record_write_capture(handle, capture);
+        ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+        k4a_capture_release(capture);
+        timestamp_ns += 1_s / 30;
+    }
+
+    result = k4a_record_flush(handle);
+    ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+
+    k4a_record_close(handle);
+
+    ASSERT_EQ(std::remove("record_test_bgra_color.mkv"), 0);
 }
 
 int main(int argc, char **argv)

--- a/tests/RecordTests/UnitTest/sample_recordings.cpp
+++ b/tests/RecordTests/UnitTest/sample_recordings.cpp
@@ -35,6 +35,10 @@ void SampleRecordings::SetUp()
     k4a_device_configuration_t record_config_depth_only = record_config_full;
     record_config_depth_only.color_resolution = K4A_COLOR_RESOLUTION_OFF;
 
+    k4a_device_configuration_t record_config_bgra_color = record_config_full;
+    record_config_bgra_color.color_format = K4A_IMAGE_FORMAT_COLOR_BGRA32;
+    record_config_bgra_color.depth_mode = K4A_DEPTH_MODE_OFF;
+
     {
         k4a_record_t handle = NULL;
         k4a_result_t result = k4a_record_create("record_test_empty.mkv", NULL, record_config_empty, &handle);
@@ -307,6 +311,28 @@ void SampleRecordings::SetUp()
 
         k4a_record_close(handle);
     }
+    { // Create a recording file with BGRA color
+        k4a_record_t handle = NULL;
+        k4a_result_t result = k4a_record_create("record_test_bgra_color.mkv", NULL, record_config_bgra_color, &handle);
+        ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+
+        result = k4a_record_write_header(handle);
+        ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+
+        uint64_t timestamps[3] = { 0, 0, 0 };
+        k4a_capture_t capture = create_test_capture(timestamps,
+                                                    record_config_bgra_color.color_format,
+                                                    record_config_bgra_color.color_resolution,
+                                                    record_config_bgra_color.depth_mode);
+        result = k4a_record_write_capture(handle, capture);
+        ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+        k4a_capture_release(capture);
+
+        result = k4a_record_flush(handle);
+        ASSERT_EQ(result, K4A_RESULT_SUCCEEDED);
+
+        k4a_record_close(handle);
+    }
 }
 
 void SampleRecordings::TearDown()
@@ -319,6 +345,7 @@ void SampleRecordings::TearDown()
     ASSERT_EQ(std::remove("record_test_offset.mkv"), 0);
     ASSERT_EQ(std::remove("record_test_color_only.mkv"), 0);
     ASSERT_EQ(std::remove("record_test_depth_only.mkv"), 0);
+    ASSERT_EQ(std::remove("record_test_bgra_color.mkv"), 0);
 }
 
 void CustomTrackRecordings::SetUp()

--- a/tests/RecordTests/UnitTest/test_helpers.cpp
+++ b/tests/RecordTests/UnitTest/test_helpers.cpp
@@ -96,6 +96,10 @@ bool validate_test_capture(k4a_capture_t capture,
             {
                 color_stride = width * 2;
             }
+            else if (color_format == K4A_IMAGE_FORMAT_COLOR_BGRA32)
+            {
+                color_stride = width * 4;
+            }
 
             k4a_image_t color_image = k4a_capture_get_color_image(capture);
             if (color_image == NULL)


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #404 

### Description of the changes:
- Allow BGRA format captures in recording
- If the write queue is more than 2 seconds behind, print a warning about slow disk speed.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

