### PR TITLE
Add set_color_conversion for recording playback

### DIFF
--- a/tools/k4aviewer/k4arecordingdockcontrol.cpp
+++ b/tools/k4aviewer/k4arecordingdockcontrol.cpp
@@ -92,6 +92,9 @@ K4ARecordingDockControl::K4ARecordingDockControl(std::string &&path, k4a::playba
     {
         colorFormatSS << m_recordConfiguration.color_format;
         colorResolutionSS << m_recordConfiguration.color_resolution;
+
+        recording.set_color_conversion(K4A_IMAGE_FORMAT_COLOR_BGRA32);
+        m_recordConfiguration.color_format = K4A_IMAGE_FORMAT_COLOR_BGRA32;
     }
     else
     {
@@ -474,12 +477,10 @@ void K4ARecordingDockControl::SetViewType(K4AWindowSet::ViewType viewType)
         try
         {
             k4a::calibration calibration = m_playbackThreadState.Recording.get_calibration();
-            bool colorPointCloudAvailable = m_recordConfiguration.color_track_enabled &&
-                                            m_recordConfiguration.color_format == K4A_IMAGE_FORMAT_COLOR_BGRA32;
             K4AWindowSet::StartPointCloudWindow(m_filenameLabel.c_str(),
                                                 std::move(calibration),
                                                 &m_playbackThreadState.CaptureDataSource,
-                                                colorPointCloudAvailable);
+                                                m_recordConfiguration.color_track_enabled);
         }
         catch (const k4a::error &e)
         {


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #990 

### Description of the changes:
- Sets the color conversion to BGRA so that colorized point cloud is usable on recordings.
-
-

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Tested on a variety of recordings formats: MJPG, NV12, YUY2
