### PR TITLE
Fix for issue #754. 

### DIFF
--- a/src/csharp/SDK/LargeArrayPool.cs
+++ b/src/csharp/SDK/LargeArrayPool.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Kinect.Sensor
                     if (x.IsAlive)
                     {
                         buffer = (byte[])x.Target;
-                        if (buffer.Length >= minimumLength)
+                        if (buffer != null && buffer.Length >= minimumLength)
                         {
                             _ = this.pool.Remove(x);
                             return buffer;

--- a/src/usbcommand/usbcommand.c
+++ b/src/usbcommand/usbcommand.c
@@ -1026,7 +1026,7 @@ k4a_result_t usb_cmd_get_device_count(uint32_t *p_device_count)
         LOG_ERROR("List too large", 0);
         return K4A_RESULT_FAILED;
     }
-    if (count == 0)
+    if (count <= 0)
     {
         LOG_ERROR("No devices found", 0);
         return K4A_RESULT_FAILED;


### PR DESCRIPTION
Fixed thread safety issue in LargePoolArray.cs. Garbage collector can be called on another thread after the x.IsAlive test and before buffer is assigned. This can lead to a null pointer exception as x.Target will be null after the garbage collector has freed it. 
(Refer to https://stackoverflow.com/questions/1687045/thread-safety-of-weakreference for more info.)

## Fixes #754

### Description of the changes:
Add a test to see if buffer is null before using it.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manually tested in application where issue was occurring. Confirmed fixed in that application.
