### PR TITLE
Lowering test task "Check OpenGL version" timeout to 5min

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -805,6 +805,7 @@ jobs:
     - script: 'env && which xauth && glxinfo | grep "OpenGL"'
       workingDirectory: '$(System.ArtifactsDirectory)'
       displayName: 'Check openGL version'
+      timeoutInMinutes: 5
 
     - script: './x86_64-linux-clang-relwithdebinfo/bin/AzureKinectFirmwareTool -r'
       workingDirectory: '$(System.ArtifactsDirectory)'


### PR DESCRIPTION
The call is hanging on builds and the default is 2 hours. The confirmation only takes seconds
