### PR TITLE
ARM64 builds should runs multi device tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -863,11 +863,7 @@ jobs:
       displayName: 'Run Functional Tests'
       timeoutInMinutes: 15
 
-    - script: |
-        # skip testing on ARM64 Jetson Nano doesn't like 2 USB devices running at once.
-        if [ $(EdenArch) == "x64" ]; then
-          python $(Build.SourcesDirectory)/scripts/RunTestList.py --list bin/functional_custom_test_list.txt --bin bin/ --output=xml --gtest_filter=-*ONBOARDING*
-        fi
+    - script: 'python $(Build.SourcesDirectory)/scripts/RunTestList.py --list bin/functional_custom_test_list.txt --bin bin/ --output=xml --gtest_filter=-*ONBOARDING*'
       workingDirectory: '$(System.ArtifactsDirectory)/$(CMakeLinuxTargetTriple)-relwithdebinfo'
       displayName: 'Run Custom Functional Tests'
       timeoutInMinutes: 15

--- a/tests/multidevice/multidevice.cpp
+++ b/tests/multidevice/multidevice.cpp
@@ -523,7 +523,14 @@ TEST_F(multidevice_sync_ft, multi_sync_validation)
     if (g_frame_rate != K4A_FRAMES_PER_SECOND_5 && g_frame_rate != K4A_FRAMES_PER_SECOND_15 &&
         g_frame_rate != K4A_FRAMES_PER_SECOND_30)
     {
+#if defined(__amd64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86)
+        printf("Using 5, 15, or 30FPS for AMD64/x86 build\n");
         int frame_rate_rand = (int)RAND_VALUE(0, 2);
+#else
+        // Jetson Nano can't handle 2 30FPS streams
+        printf("Using 5 or 15FPS for ARM64 build\n");
+        int frame_rate_rand = (int)RAND_VALUE(0, 1);
+#endif
         switch (frame_rate_rand)
         {
         case 0:


### PR DESCRIPTION
### Description of the changes:
- Nano doesn't like to 30FPS devices running at the same time. So we limit max speed to 15FPS
