### PR TITLE
add NEON support where SSE is supported

### DIFF
--- a/src/transformation/rgbz.c
+++ b/src/transformation/rgbz.c
@@ -1100,17 +1100,17 @@ static void transformation_depth_to_xyz(k4a_transformation_xy_tables_t *xy_table
 // make separate function to do floor
 static inline int32x4_t neon_floor(float32x4_t v)
 {
-        int32x4_t v0 = vcvtq_s32_f32(v);
-        int32x4_t a0 = vreinterpretq_s32_u32(vcgtq_f32(vcvtq_f32_s32(v0), v));
-        return vaddq_s32(v0, a0);
+    int32x4_t v0 = vcvtq_s32_f32(v);
+    int32x4_t a0 = vreinterpretq_s32_u32(vcgtq_f32(vcvtq_f32_s32(v0), v));
+    return vaddq_s32(v0, a0);
 }
 
 static void transformation_depth_to_xyz(k4a_transformation_xy_tables_t *xy_tables,
                                         const void *depth_image_data,
                                         void *xyz_image_data)
 {
-    float* x_tab = (float*)xy_tables->x_table;
-    float* y_tab = (float*)xy_tables->y_table;
+    float *x_tab = (float *)xy_tables->x_table;
+    float *y_tab = (float *)xy_tables->y_table;
     const uint16_t *depth_image_data_uint16 = (const uint16_t *)depth_image_data;
     int16_t *xyz_data_int16 = (int16_t *)xyz_image_data;
     float32x4_t half = vdupq_n_f32(0.5f);
@@ -1128,7 +1128,7 @@ static void transformation_depth_to_xyz(k4a_transformation_xy_tables_t *xy_table
         uint16x8_t valid = vcombine_u16(vmovn_u32(valid_lo), vmovn_u32(valid_hi));
         // v_z corresponds to z in naive code
         int16x8_t v_z = vreinterpretq_s16_u16(vandq_u16(vld1q_u16(depth_image_data_uint16), valid));
-        float32x4_t v_z_lo = vcvtq_f32_u32(vmovl_u16(vget_low_u16 (vreinterpretq_u16_s16(v_z))));
+        float32x4_t v_z_lo = vcvtq_f32_u32(vmovl_u16(vget_low_u16(vreinterpretq_u16_s16(v_z))));
         float32x4_t v_z_hi = vcvtq_f32_u32(vmovl_u16(vget_high_u16(vreinterpretq_u16_s16(v_z))));
         // load x_table and y_table
         float32x4_t t_x_lo = vld1q_f32(x_tab + offset);

--- a/src/transformation/rgbz.c
+++ b/src/transformation/rgbz.c
@@ -64,15 +64,11 @@ typedef struct _k4a_bounding_box_t
 static char g_transformation_instruction_type[5] = { 0 };
 
 // Share g_transformation_instruction_type with tests to confirm this is built correctly.
+char *transformation_get_instruction_type();
 char *transformation_get_instruction_type()
 {
     return g_transformation_instruction_type;
 }
-
-// g_transformation_instruction_type settings
-#define SPECIAL_INSTRUCTION_OPTIMIZATION_SSE "SSE"
-#define SPECIAL_INSTRUCTION_OPTIMIZATION_NEON "NEON"
-#define SPECIAL_INSTRUCTION_OPTIMIZATION_NONE "None"
 
 // Set the special instruction
 static void set_special_instruction_optimization(char *opt)
@@ -1098,7 +1094,7 @@ static void transformation_depth_to_xyz(k4a_transformation_xy_tables_t *xy_table
     int16_t *xyz_data_int16 = (int16_t *)xyz_image_data;
     int16_t x, y, z;
 
-    set_special_instruction_optimization(SPECIAL_INSTRUCTION_OPTIMIZATION_NONE);
+    set_special_instruction_optimization("None");
 
     for (int i = 0; i < xy_tables->width * xy_tables->height; i++)
     {
@@ -1143,7 +1139,7 @@ static void transformation_depth_to_xyz(k4a_transformation_xy_tables_t *xy_table
     int16_t *xyz_data_int16 = (int16_t *)xyz_image_data;
     float32x4_t half = vdupq_n_f32(0.5f);
 
-    set_special_instruction_optimization(SPECIAL_INSTRUCTION_OPTIMIZATION_NEON);
+    set_special_instruction_optimization("NEON");
 
     for (int i = 0; i < xy_tables->width * xy_tables->height / 8; i++)
     {
@@ -1202,7 +1198,7 @@ static void transformation_depth_to_xyz(k4a_transformation_xy_tables_t *xy_table
     __m128 *y_table_m128 = (__m128 *)y_table;
     __m128i *xyz_data_m128i = (__m128i *)xyz_image_data;
 
-    set_special_instruction_optimization(SPECIAL_INSTRUCTION_OPTIMIZATION_SSE);
+    set_special_instruction_optimization("SSE");
 
     const int16_t pos0 = 0x0100;
     const int16_t pos1 = 0x0302;

--- a/src/transformation/rgbz.c
+++ b/src/transformation/rgbz.c
@@ -8,7 +8,7 @@
 #include <limits.h>
 #include <math.h>
 
-#if defined(__amd64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86)
+#if defined(__amd64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_IX86)
 #define K4A_USING_SSE
 #include <emmintrin.h> // SSE2
 #include <tmmintrin.h> // SSE3
@@ -64,8 +64,8 @@ typedef struct _k4a_bounding_box_t
 static char g_transformation_instruction_type[5] = { 0 };
 
 // Share g_transformation_instruction_type with tests to confirm this is built correctly.
-char *transformation_get_instruction_type();
-char *transformation_get_instruction_type()
+char *transformation_get_instruction_type(void);
+char *transformation_get_instruction_type(void)
 {
     return g_transformation_instruction_type;
 }

--- a/tests/Transformation/transformation.cpp
+++ b/tests/Transformation/transformation.cpp
@@ -411,16 +411,19 @@ TEST_F(transformation_ut, transformation_depth_image_to_point_cloud)
     {
         // Are we compiled for the correct instruction type
 #if defined(__amd64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86)
-#define SPECIAL_INSTRUCTION_OPTIMIZATION "SSE\0\0"
+#define SPECIAL_INSTRUCTION_OPTIMIZATION "SSE\0"
 #elif defined(__aarch64__) || defined(_M_ARM64)
-#define SPECIAL_INSTRUCTION_OPTIMIZATION "NEON\0"
+#define SPECIAL_INSTRUCTION_OPTIMIZATION "NEON"
 #else
-#define SPECIAL_INSTRUCTION_OPTIMIZATION "None\0"
+// Omit defining this when not SSE or NEON. Should result in a build break. We are either SSE or Neon.
+//#define SPECIAL_INSTRUCTION_OPTIMIZATION "None"
 #endif
         char *compile_type = transformation_get_instruction_type();
         ASSERT_NE(compile_type, (char *)nullptr);
         ASSERT_NE(compile_type[0], '\0');
         std::cout << "*** K4A Sensor SDK Compile type is: " << compile_type << " ***\n";
+        ASSERT_TRUE(memcmp(compile_type, SPECIAL_INSTRUCTION_OPTIMIZATION, strlen(compile_type)) == 0)
+            << "Expecting " << SPECIAL_INSTRUCTION_OPTIMIZATION << " but compiled for " << compile_type << "\n";
         ASSERT_TRUE(memcmp(compile_type, SPECIAL_INSTRUCTION_OPTIMIZATION, strlen(compile_type)) == 0)
             << "Expecting " << SPECIAL_INSTRUCTION_OPTIMIZATION << " but compiled for " << compile_type << "\n";
         ASSERT_EQ(strlen(compile_type), strlen(SPECIAL_INSTRUCTION_OPTIMIZATION));

--- a/tests/Transformation/transformation.cpp
+++ b/tests/Transformation/transformation.cpp
@@ -84,6 +84,9 @@ protected:
         ASSERT_EQ_FLT(A[2], B[2])                                                                                      \
     }
 
+// Export function from transformation.c to snoop on the compiler setting used.
+extern "C" char *transformation_get_instruction_type();
+
 static k4a_transformation_image_descriptor_t image_get_descriptor(const k4a_image_t image)
 {
     k4a_transformation_image_descriptor_t descriptor;
@@ -403,6 +406,24 @@ TEST_F(transformation_ut, transformation_depth_image_to_point_cloud)
     if (std::abs(check_sum - reference_val) > 0.001)
     {
         ASSERT_EQ(check_sum, reference_val);
+    }
+
+    {
+        // Are we compiled for the correct instruction type
+#if defined(__amd64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86)
+#define SPECIAL_INSTRUCTION_OPTIMIZATION "SSE\0\0"
+#elif defined(__aarch64__) || defined(_M_ARM64)
+#define SPECIAL_INSTRUCTION_OPTIMIZATION "NEON\0"
+#else
+#define SPECIAL_INSTRUCTION_OPTIMIZATION "None\0"
+#endif
+        char *compile_type = transformation_get_instruction_type();
+        ASSERT_NE(compile_type, (char *)nullptr);
+        ASSERT_NE(compile_type[0], '\0');
+        std::cout << "*** K4A Sensor SDK Compile type is: " << compile_type << " ***\n";
+        ASSERT_TRUE(memcmp(compile_type, SPECIAL_INSTRUCTION_OPTIMIZATION, strlen(compile_type)) == 0)
+            << "Expecting " << SPECIAL_INSTRUCTION_OPTIMIZATION << " but compiled for " << compile_type << "\n";
+        ASSERT_EQ(strlen(compile_type), strlen(SPECIAL_INSTRUCTION_OPTIMIZATION));
     }
 
     image_dec_ref(depth_image);

--- a/tests/Transformation/transformation.cpp
+++ b/tests/Transformation/transformation.cpp
@@ -410,7 +410,7 @@ TEST_F(transformation_ut, transformation_depth_image_to_point_cloud)
 
     {
         // Are we compiled for the correct instruction type
-#if defined(__amd64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86)
+#if defined(__amd64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_IX86)
 #define SPECIAL_INSTRUCTION_OPTIMIZATION "SSE\0"
 #elif defined(__aarch64__) || defined(_M_ARM64)
 #define SPECIAL_INSTRUCTION_OPTIMIZATION "NEON"

--- a/tests/multidevice/multidevice.cpp
+++ b/tests/multidevice/multidevice.cpp
@@ -523,13 +523,13 @@ TEST_F(multidevice_sync_ft, multi_sync_validation)
     if (g_frame_rate != K4A_FRAMES_PER_SECOND_5 && g_frame_rate != K4A_FRAMES_PER_SECOND_15 &&
         g_frame_rate != K4A_FRAMES_PER_SECOND_30)
     {
-#if defined(__amd64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_X86)
-        printf("Using 5, 15, or 30FPS for AMD64/x86 build\n");
-        int frame_rate_rand = (int)RAND_VALUE(0, 2);
-#else
+#if defined(__aarch64__) || defined(_M_ARM64)
         // Jetson Nano can't handle 2 30FPS streams
         printf("Using 5 or 15FPS for ARM64 build\n");
         int frame_rate_rand = (int)RAND_VALUE(0, 1);
+#else
+        printf("Using 5, 15, or 30FPS for AMD64/x86 build\n");
+        int frame_rate_rand = (int)RAND_VALUE(0, 2);
 #endif
         switch (frame_rate_rand)
         {


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #1118 

### Description of the changes:
- Added NEON implementation of rgbz.c
- Only supposed to work on aarch64.  Arm 32bit is excluded intentionally.
- Using [sse2neon](https://github.com/DLTcollab/sse2neon) could be faster to implement but that couldn't leverage the `vst3` instruction that NEON has

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

- Ran `transformation_ut` on Jetson TX2 (Aarch64) without actual device