### PR TITLE
K4aRecorder updated to not set gain to auto 

### DIFF
--- a/src/color/mfcamerareader.cpp
+++ b/src/color/mfcamerareader.cpp
@@ -484,6 +484,10 @@ k4a_result_t CMFCameraReader::Start(const UINT32 width,
         LOG_WARNING("Start request in started state", 0);
     }
 
+    if (FAILED(hr))
+    {
+        LOG_ERROR("Failing with HRESULT:%08X", hr);
+    }
     return k4aResultFromHRESULT(hr);
 }
 
@@ -691,6 +695,10 @@ k4a_result_t CMFCameraReader::GetCameraControlCapabilities(const k4a_color_contr
         capabilities->valid = true;
     }
 
+    if (FAILED(hr))
+    {
+        LOG_ERROR("Failing command %u with HRESULT:%08X", command, hr);
+    }
     return k4aResultFromHRESULT(hr);
 }
 
@@ -819,6 +827,10 @@ k4a_result_t CMFCameraReader::GetCameraControl(const k4a_color_control_command_t
         *pValue = (int32_t)propertyValue;
     }
 
+    if (FAILED(hr))
+    {
+        LOG_ERROR("Failing command %u with HRESULT:%08X", command, hr);
+    }
     return k4aResultFromHRESULT(hr);
 }
 
@@ -925,9 +937,14 @@ k4a_result_t CMFCameraReader::SetCameraControl(const k4a_color_control_command_t
     }
     break;
     default:
+        LOG_ERROR("Failing, unknown command %u", command);
         return K4A_RESULT_FAILED;
     }
 
+    if (FAILED(hr))
+    {
+        LOG_ERROR("Failing command %u with HRESULT:%08X", command, hr);
+    }
     return k4aResultFromHRESULT(hr);
 }
 

--- a/tools/k4arecorder/recorder.cpp
+++ b/tools/k4arecorder/recorder.cpp
@@ -121,13 +121,6 @@ int do_recording(uint8_t device_index,
             std::cerr << "Runtime error: k4a_device_set_color_control() for manual gain failed " << std::endl;
         }
     }
-    else
-    {
-        if (K4A_FAILED(k4a_device_set_color_control(device, K4A_COLOR_CONTROL_GAIN, K4A_COLOR_CONTROL_MODE_AUTO, 0)))
-        {
-            std::cerr << "Runtime error: k4a_device_set_color_control() for auto gain failed " << std::endl;
-        }
-    }
 
     CHECK(k4a_device_start_cameras(device, device_config), device);
     if (record_imu)


### PR DESCRIPTION
## Fixes #1165

### Description of the changes:
- Removed code to set auto gain - that is not supported
- Added debug info

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [x] Linux
- [x] Arm
