### PR TITLE
Dropping failed conversions from MJPEG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Change Log
 
 ### v1.4.1
+
 * Added NEON for ARM64
+* Failed conversion of MJPEG to BGRA is a warning - no long an error.
 
 ### v1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### v1.4.1
 
 * Added NEON for ARM64
-* Failed conversion of MJPEG to BGRA is a warning - no long an error.
+* Failed conversion of MJPEG to BGRA is now a warning - not an error.
 
 ### v1.4.0
 


### PR DESCRIPTION
## Fixes #1187 

### Description of the changes:
- Drops image that fails to be decoded, which happens on PC's that are heavily loaded and can't always read image from sensor fast enough

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux

Manual Testing will be done on Ubuntu with 3 camera's starting and stopping at random intervals. Expectation is that we will see warnings of dropped frames but no errors. 

NOTE: K4AViewer converts YUY and NV12 to bgra format for displaying purposes which are not being addressed. So those formats in that tool will still fail.
