### PR TITLE
Suppress Some CMake Warnings

### DIFF
--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -56,6 +56,14 @@ endif()
 # NEW is the default for this policy except when cmake_minimum_required is
 # lower than CMake 3.3
 set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)
+# Set default policies for CMP0064 to NEW
+# It will suppress the CMake Warnings that occurs at dependences. 
+# Related: libjpeg-turbo
+set(CMAKE_POLICY_DEFAULT_CMP0064 NEW)
+# Set default policies for CMP0048 to NEW
+# It will suppress the CMake Warnings that occurs at dependences.
+# Related: azure_c_shared (azure-macro-utils-c, umock-c), libjpeg-turbo
+set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
 
 add_subdirectory(azure_c_shared)
 add_subdirectory(cjson)


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #1368

### Description of the changes:
- This commit will suppress CMake warnings CMP0064 and CMP0048 by set default policies.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

