### PR TITLE
Fix build with libmatroska 1.6.x

### DIFF
--- a/src/record/sdk/record.cpp
+++ b/src/record/sdk/record.cpp
@@ -543,7 +543,7 @@ k4a_result_t k4a_record_write_header(const k4a_record_t recording_handle)
             EbmlHead file_head;
 
             GetChild<EDocType>(file_head).SetValue("matroska");
-            GetChild<EDocTypeVersion>(file_head).SetValue(MATROSKA_VERSION);
+            GetChild<EDocTypeVersion>(file_head).SetValue(2);
             GetChild<EDocTypeReadVersion>(file_head).SetValue(2);
 
             file_head.Render(*context->ebml_file, true);


### PR DESCRIPTION
The `MATROSKA_VERSION` define is gone as it was an ancient compilation flag to support writing Matroska v1 files.

Since the `EDocTypeReadVersion` is 2 in the next line, using 2 as the Matroska version of the file seems the correct value to use. That's the value that was used when `MATROSKA_VERSION` was there.

Fixes the issue mentioned here https://github.com/Matroska-Org/libmatroska/issues/41#issuecomment-693278668