### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/include/k4a/k4a.h
+++ b/include/k4a/k4a.h
@@ -2214,7 +2214,8 @@ K4A_EXPORT k4a_result_t k4a_transformation_color_image_to_depth_camera(k4a_trans
                                                                        const k4a_image_t color_image,
                                                                        k4a_image_t transformed_color_image);
 
-/** Transforms the depth image into 3 planar images representing X, Y and Z-coordinates of corresponding 3D points.
+/** Transforms the depth image into a single image with voxels representing
+ * X, Y and Z-coordinates in millimeters of corresponding 3D points.
  *
  * \param transformation_handle
  * Transformation handle.


### PR DESCRIPTION
k4a_transformation_depth_image_to_point_cloud() transforms
the depth image into a single image, not 3 planar images

Signed-off-by: v-hkazakov <v-hkazakov@microsoft.com>

<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #1287

### Description of the changes:
- Fixed a typo in the k4a.h

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

