### PR TITLE
Add template parameter to get_buffer()

### DIFF
--- a/examples/viewer/opengl/main.cpp
+++ b/examples/viewer/opengl/main.cpp
@@ -105,7 +105,7 @@ int main()
                 // If you want to use one of the other modes, you have to do the conversion
                 // yourself.
                 //
-                colorTexture.Update(reinterpret_cast<const BgraPixel *>(colorImage.get_buffer()));
+                colorTexture.Update(colorImage.get_buffer<const BgraPixel>());
             }
 
             // Show the windows
@@ -154,7 +154,7 @@ void ColorizeDepthImage(const k4a::image &depthImage,
 
     buffer->resize(static_cast<size_t>(width * height));
 
-    const uint16_t *depthData = reinterpret_cast<const uint16_t *>(depthImage.get_buffer());
+    const uint16_t *depthData = depthImage.get_buffer<const uint16_t>();
     for (int h = 0; h < height; ++h)
     {
         for (int w = 0; w < width; ++w)

--- a/include/k4a/k4a.hpp
+++ b/include/k4a/k4a.hpp
@@ -262,18 +262,20 @@ public:
      *
      * \sa k4a_image_get_buffer
      */
-    uint8_t *get_buffer() noexcept
+    template<typename T = uint8_t>
+    T *get_buffer() noexcept
     {
-        return k4a_image_get_buffer(m_handle);
+        return reinterpret_cast<T*>(k4a_image_get_buffer(m_handle));
     }
 
     /** Get the image buffer
      *
      * \sa k4a_image_get_buffer
      */
-    const uint8_t *get_buffer() const noexcept
+    template<typename T = uint8_t>
+    const T *get_buffer() const noexcept
     {
-        return k4a_image_get_buffer(m_handle);
+        return reinterpret_cast<T*>(k4a_image_get_buffer(m_handle));
     }
 
     /** Get the image buffer size in bytes


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #1499 

### Description of the changes:
-Added a c++ template parameter to `k4a::image::get_buffer()` so that the pointer type returned can be easily controlled. There is a significant probability the image buffer doesn't contain 8-bit data, and a significant probability the caller needs a pointer other than `uint8_t*`. This is extremely common when interoperating with OpenCV

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [X] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [X] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [X] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [X] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [X] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [X] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

