### PR TITLE
Fix Close Device of Python API

### DIFF
--- a/src/python/k4a/src/k4a/_bindings/device.py
+++ b/src/python/k4a/src/k4a/_bindings/device.py
@@ -121,8 +121,8 @@ class Device:
         pass
 
     def __del__(self):
-
-        # Ensure that handle is closed.
+        self.stop_cameras()
+        self.stop_imu()
         self.close()
 
         del self.__device_handle
@@ -276,9 +276,13 @@ class Device:
             been deleted to ensure that all memory is freed.
         '''
 
-        self.stop_cameras()
-        self.stop_imu()
+        if self.__device_handle is None:
+            return
+
         k4a_device_close(self.__device_handle)
+
+        del self.__device_handle
+        self.__device_handle = None
 
     def get_capture(self, timeout_ms:int)->Capture:
         '''! Reads a sensor capture.
@@ -435,6 +439,9 @@ class Device:
         
         @see start_cameras
         '''
+        if self.__device_handle is None:
+            return
+
         k4a_device_stop_cameras(self.__device_handle)
 
     def start_imu(self)->EStatus:
@@ -469,6 +476,9 @@ class Device:
             in get_imu_sample(). Calling this function while another thread is
             in that function will result in that function returning a failure.
         '''
+        if self.__device_handle is None:
+            return
+
         k4a_device_stop_imu(self.__device_handle)
 
     def get_color_control(self, 


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #1557


### Description of the changes:
- Add check if device handle is None to close(), stop_cameras(), and stop_imu().
- Call stop_cameras() and stop_imu() in destructor instead of calling them in close().

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [x] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

