### PR TITLE
Replace C clock with steady_clock

### DIFF
--- a/tools/k4arecorder/main.cpp
+++ b/tools/k4arecorder/main.cpp
@@ -14,10 +14,13 @@
 #include <iostream>
 #include <atomic>
 #include <ctime>
+#include <chrono>
 #include <csignal>
 #include <math.h>
 
-static time_t exiting_timestamp;
+using namespace std::chrono;
+
+static steady_clock::time_point exiting_timestamp;
 
 static void signal_handler(int s)
 {
@@ -26,11 +29,11 @@ static void signal_handler(int s)
     if (!exiting)
     {
         std::cout << "Stopping recording..." << std::endl;
-        exiting_timestamp = clock();
+        exiting_timestamp = steady_clock::now();
         exiting = true;
     }
     // If Ctrl-C is received again after 1 second, force-stop the application since it's not responding.
-    else if (exiting_timestamp != 0 && clock() - exiting_timestamp > CLOCKS_PER_SEC)
+    else if (steady_clock::now() - exiting_timestamp > seconds(1))
     {
         std::cout << "Forcing stop." << std::endl;
         exit(1);


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #1584

### Description of the changes:
`clock()` reports CPU time and not the 'wall time'.
Without this fix recording obtained by `k4arecorder` will be longer than
the time passed to the `--record-length` argument.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

