### PR TITLE
fix cmake version var, missing ver patch

### DIFF
--- a/cmake/K4AProjectVersion.cmake
+++ b/cmake/K4AProjectVersion.cmake
@@ -12,7 +12,10 @@ endfunction()
 
 # Set the default version string if it wasn't defined in the build configuration
 if (NOT DEFINED VERSION_STR)
-    set(VERSION_STR "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.0-private")
+    if (NOT PROJECT_VERSION_PATCH)
+        set(PROJECT_VERSION_PATCH 0)
+    endif()
+    set(VERSION_STR "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}-private")
 endif()
 
 set(SEMVER_REGEX "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\-([a-zA-Z0-9\\._]+))?(\\+([a-zA-Z0-9\\._]+))?$")
@@ -36,7 +39,7 @@ set(K4A_VERSION_MAJOR ${CMAKE_MATCH_1})
 set(K4A_VERSION_MINOR ${CMAKE_MATCH_2})
 set(K4A_VERSION_PATCH ${CMAKE_MATCH_3})
 set(K4A_VERSION_PRERELEASE ${CMAKE_MATCH_5})
-set(K4A_VERSION_BUILDMETADATA ${CMAKE_MATCH_7})
+set(K4A_VERSION_BUILD_METADATA ${CMAKE_MATCH_7})
 set(K4A_VERSION_STR ${VERSION_STR})
 
 if (NOT K4A_VERSION_REVISION)


### PR DESCRIPTION
## Fixes #

- code used wrong variable name, was missing underscore
- code did not allow version-patch, now defaults to 0 while also allowing it

### Description of the changes:
- put an underscore
- put test for patch ver and default to zero

### Before submitting a Pull Request:
- [X] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [X] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [X] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [X] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [n/a] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on:
- [X] Windows
- [ ] Linux

Tested via: project's test scripts, and my own project.
