### PR TITLE
Fix path in documentation

### DIFF
--- a/examples/calibration_registration/README.md
+++ b/examples/calibration_registration/README.md
@@ -60,7 +60,7 @@ The script `register.py`, like `calibrate.py` is designed to take in command lin
    2. Find the five files you will need. Two images (one per camera) taken at the same time and the corresponding `calib.yml` calibration files generated for a well calibrated camera. Also pass in the template file.
         * Example: RGB and IR images taken simultaneously.
         * ![Color Image](example_files/registration/color-0.jpg "Color Image")
-        * ![IR Image](example_files\registration/ir-0.png "IR Image")
+        * ![IR Image](example_files/registration/ir-0.png "IR Image")
    3. If you already have a collected set of data, run the calibration code this way:
 
         ``` windows


### PR DESCRIPTION
### Fixes documentation not rendering properly and a 404-URL in documentation

Before:

![image](https://user-images.githubusercontent.com/11834788/153343422-79de99b3-2f4b-438a-a0d7-81657ed346f5.png)

After:
![image](https://user-images.githubusercontent.com/11834788/153343368-adaac02b-bcc2-456b-978e-fa899cb697e8.png)

Kindly ignore and close the PR if the trivial change is not required.