### PR TITLE
Support for all color camera parameters in k4arecorder

### DIFF
--- a/tools/k4arecorder/main.cpp
+++ b/tools/k4arecorder/main.cpp
@@ -123,6 +123,11 @@ int main(int argc, char **argv)
     int32_t depth_delay_off_color_usec = 0;
     uint32_t subordinate_delay_off_master_usec = 0;
     int absoluteExposureValue = defaultExposureAuto;
+    int whiteBalance = defaultWhiteBalance;
+    int brightness = defaultBrightness;
+    int contrast = defaultContrast;
+    int saturation = defaultSaturation;
+    int sharpness = defaultSharpness;
     int gain = defaultGainAuto;
     char *recording_filename;
 
@@ -346,6 +351,67 @@ int main(int argc, char **argv)
                                       throw std::runtime_error("Exposure value range is 2 to 5s, or -11 to 1.");
                                   }
                               });
+    cmd_parser.RegisterOption("-w|--white-balance",
+                              "Set manual white balance from 2500K to 12500K for the RGB camera (default: \n"
+                              "auto white balance). The value has to be divisible by 10.",
+                              1,
+                              [&](const std::vector<char *> &args) {
+                                  int whiteBalanceSetting = std::stoi(args[0]);
+                                  if (whiteBalanceSetting < 2500 || whiteBalanceSetting > 12500 ||
+                                      whiteBalanceSetting % 10 != 0)
+                                  {
+                                      throw std::runtime_error("White balance setting has invalid value.");
+                                  }
+                                  whiteBalance = whiteBalanceSetting;
+                              });
+    cmd_parser.RegisterOption("--brightness",
+                              "Set brightness from 0 to 255 for the RGB camera (default: \n"
+                              "previously set value, non deterministic).",
+                              1,
+                              [&](const std::vector<char *> &args) {
+                                  int brightnessSetting = std::stoi(args[0]);
+                                  if (brightnessSetting < 0 || brightnessSetting > 255)
+                                  {
+                                      throw std::runtime_error("Brightness setting has invalid value.");
+                                  }
+                                  brightness = brightnessSetting;
+                              });
+    cmd_parser.RegisterOption("--contrast",
+                              "Set contrast from 0 to 10 for the RGB camera (default: \n"
+                              "previously set value, non deterministic).",
+                              1,
+                              [&](const std::vector<char *> &args) {
+                                  int contrastSetting = std::stoi(args[0]);
+                                  if (contrastSetting < 0 || contrastSetting > 10)
+                                  {
+                                      throw std::runtime_error("Contrast setting has invalid value.");
+                                  }
+                                  contrast = contrastSetting;
+                              });
+    cmd_parser.RegisterOption("--saturation",
+                              "Set saturation from 0 to 63 for the RGB camera (default: \n"
+                              "previously set value, non deterministic).",
+                              1,
+                              [&](const std::vector<char *> &args) {
+                                  int saturationSetting = std::stoi(args[0]);
+                                  if (saturationSetting < 0 || saturationSetting > 63)
+                                  {
+                                      throw std::runtime_error("Saturation setting has invalid value.");
+                                  }
+                                  saturation = saturationSetting;
+                              });
+    cmd_parser.RegisterOption("--sharpness",
+                              "Set sharpness from 0 to 4 for the RGB camera (default: \n"
+                              "previously set value, non deterministic).",
+                              1,
+                              [&](const std::vector<char *> &args) {
+                                  int sharpnessSetting = std::stoi(args[0]);
+                                  if (sharpnessSetting < 0 || sharpnessSetting > 4)
+                                  {
+                                      throw std::runtime_error("Sharpness setting has invalid value.");
+                                  }
+                                  sharpness = sharpnessSetting;
+                              });
     cmd_parser.RegisterOption("-g|--gain",
                               "Set cameras manual gain. The valid range is 0 to 255. (default: auto)",
                               1,
@@ -433,5 +499,10 @@ int main(int argc, char **argv)
                         &device_config,
                         recording_imu_enabled,
                         absoluteExposureValue,
+                        whiteBalance,
+                        brightness,
+                        contrast,
+                        saturation,
+                        sharpness,
                         gain);
 }

--- a/tools/k4arecorder/recorder.cpp
+++ b/tools/k4arecorder/recorder.cpp
@@ -77,8 +77,8 @@ void set_color_param(k4a_device_t &device,
     }
 
     k4a_device_get_color_control(device, command, &read_mode, &read_value);
-    std::cout << "Current " << (read_mode == K4A_COLOR_CONTROL_MODE_AUTO ? "AUTO" : "MANUAL") << command_name << " value: " << read_value
-                                                                        << std::endl;
+    std::cout << "Current " << command_name << " set to " << (read_mode == K4A_COLOR_CONTROL_MODE_AUTO ? "AUTO" : "MANUAL") << " mode and has value " << read_value
+        << std::endl;
 }
 
 int do_recording(uint8_t device_index,
@@ -144,7 +144,7 @@ int do_recording(uint8_t device_index,
     set_color_param(device, K4A_COLOR_CONTROL_BRIGHTNESS, "brightness", brightness, defaultBrightness, false);
     set_color_param(device, K4A_COLOR_CONTROL_CONTRAST, "contrast", contrast, defaultContrast, false);
     set_color_param(device, K4A_COLOR_CONTROL_SATURATION, "saturation", saturation, defaultSaturation, false);
-    set_color_param(device, K4A_COLOR_CONTROL_SHARPNESS, "brightness", sharpness, defaultSharpness, false);
+    set_color_param(device, K4A_COLOR_CONTROL_SHARPNESS, "sharpness", sharpness, defaultSharpness, false);
     set_color_param(device, K4A_COLOR_CONTROL_GAIN, "gain", gain, defaultGainAuto, false);
 
     CHECK(k4a_device_start_cameras(device, device_config), device);

--- a/tools/k4arecorder/recorder.cpp
+++ b/tools/k4arecorder/recorder.cpp
@@ -50,7 +50,7 @@ std::atomic_bool exiting(false);
 
 void set_color_param(k4a_device_t &device,
                      k4a_color_control_command_t command,
-                     const char *command_name, 
+                     const char *command_name,
                      int32_t value,
                      int32_t defaultValue,
                      bool defaultAuto)
@@ -60,25 +60,24 @@ void set_color_param(k4a_device_t &device,
 
     if (value != defaultValue)
     {
-        if (K4A_FAILED(k4a_device_set_color_control(device, command,
-                                                    K4A_COLOR_CONTROL_MODE_MANUAL, value)))
+        if (K4A_FAILED(k4a_device_set_color_control(device, command, K4A_COLOR_CONTROL_MODE_MANUAL, value)))
         {
-            std::cerr << "Runtime error: k4a_device_set_color_control() failed for manual " << command_name << std::endl;
+            std::cerr << "Runtime error: k4a_device_set_color_control() failed for manual " << command_name
+                      << std::endl;
         }
     }
     else if (defaultAuto)
     {
-        if (K4A_FAILED(k4a_device_set_color_control(device, command,
-                                                    K4A_COLOR_CONTROL_MODE_AUTO,
-                                                    0)))
+        if (K4A_FAILED(k4a_device_set_color_control(device, command, K4A_COLOR_CONTROL_MODE_AUTO, 0)))
         {
             std::cerr << "Runtime error: k4a_device_set_color_control() failed for auto " << command_name << std::endl;
         }
     }
 
     k4a_device_get_color_control(device, command, &read_mode, &read_value);
-    std::cout << "Current " << command_name << " set to " << (read_mode == K4A_COLOR_CONTROL_MODE_AUTO ? "AUTO" : "MANUAL") << " mode and has value " << read_value
-        << std::endl;
+    std::cout << "Current " << command_name << " set to "
+              << (read_mode == K4A_COLOR_CONTROL_MODE_AUTO ? "AUTO" : "MANUAL") << " mode and has value " << read_value
+              << std::endl;
 }
 
 int do_recording(uint8_t device_index,

--- a/tools/k4arecorder/recorder.h
+++ b/tools/k4arecorder/recorder.h
@@ -10,6 +10,11 @@
 extern std::atomic_bool exiting;
 
 static const int32_t defaultExposureAuto = -12;
+static const int32_t defaultWhiteBalance = -1;
+static const int32_t defaultBrightness = -1;
+static const int32_t defaultContrast = -1;
+static const int32_t defaultSaturation = -1;
+static const int32_t defaultSharpness = -1;
 static const int32_t defaultGainAuto = -1;
 
 int do_recording(uint8_t device_index,
@@ -18,6 +23,11 @@ int do_recording(uint8_t device_index,
                  k4a_device_configuration_t *device_config,
                  bool record_imu,
                  int32_t absoluteExposureValue,
+                 int32_t whiteBalance,
+                 int32_t brightness,
+                 int32_t contrast,
+                 int32_t saturation,
+                 int32_t sharpness,
                  int32_t gain);
 
 #endif /* RECORDER_H */


### PR DESCRIPTION
## Fixes #1722

### Description of the changes:
- Adding color camera parameters to k4arecorder tool

### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [x] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [x] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on:
- [x] Windows
- [ ] Linux

My team has been using this build successfully for the past 9 months. We've been replacing the default 1.4.1 k4arecorder using this msi: https://github.com/borosko/Azure-Kinect-Sensor-SDK/releases/tag/coloropt
