### PR TITLE
Updating Targetframework to netcoreapp3.1

### DIFF
--- a/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
+++ b/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
+++ b/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
+++ b/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
+++ b/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
+++ b/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
+++ b/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
+++ b/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
+++ b/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
+++ b/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
Updating TargetFramework for C# projects

## Fixes #
This PR fixes build errors for C# projects.

### Description of the changes:
- .netcoreapp2.1 has been out of support and the runtime is no longer available on the agent. Using netcoreapp3.1 instead.

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [ ] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [ ] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

