### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,6 +70,18 @@ Each package contains different elements.
 * Development package - contains headers and cmake files to build against libk4a.
 * Tools package - contains k4aviewer and k4arecorder
 
+## Installing using vcpkg
+
+You can build and install azure-kinect-sensor-sdk using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+* git clone https://github.com/Microsoft/vcpkg.git
+* cd vcpkg
+* ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+* ./vcpkg integrate install
+* ./vcpkg install azure-kinect-sensor-sdk
+
+The azure-kinect-sensor-sdk port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Using tools
 
 The installer comes with a pre-built viewer application (k4aviewer.exe) which can be used to verify the


### PR DESCRIPTION
Azure-kinect-sensor-sdk is available as a port in vcpkg, a C++ library manager that simplifies installation for azure-kinect-sensor-sdk and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build azure-kinect-sensor-sdk, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/azure-kinect-sensor-sdk/portfile.cmake). We try to keep the library maintained as close as possible to the original library.