### PR TITLE
fix imgui delete function

### DIFF
--- a/tools/k4aviewer/k4adevicedockcontrol.cpp
+++ b/tools/k4aviewer/k4adevicedockcontrol.cpp
@@ -333,7 +333,7 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
 
     if (m_firstRun || depthEnabledStateChanged)
     {
-        ImGui::SetNextTreeNodeOpen(m_config.EnableDepthCamera);
+        ImGui::SetNextItemOpen(m_config.EnableDepthCamera);
     }
 
     ImGui::Indent();
@@ -376,7 +376,7 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
 
     if (m_firstRun || colorEnableStateChanged)
     {
-        ImGui::SetNextTreeNodeOpen(m_config.EnableColorCamera);
+        ImGui::SetNextItemOpen(m_config.EnableColorCamera);
     }
 
     ImGui::Indent();
@@ -710,7 +710,7 @@ K4ADockControlStatus K4ADeviceDockControl::Show()
 
     if (m_firstRun && (m_syncInConnected || m_syncOutConnected))
     {
-        ImGui::SetNextTreeNodeOpen(true);
+        ImGui::SetNextItemOpen(true);
     }
     if (ImGui::TreeNode("External Sync"))
     {

--- a/tools/k4aviewer/k4asourceselectiondockcontrol.cpp
+++ b/tools/k4aviewer/k4asourceselectiondockcontrol.cpp
@@ -34,7 +34,7 @@ K4ASourceSelectionDockControl::K4ASourceSelectionDockControl()
 
 K4ADockControlStatus K4ASourceSelectionDockControl::Show()
 {
-    ImGui::SetNextTreeNodeOpen(true, ImGuiCond_FirstUseEver);
+    ImGui::SetNextItemOpen(true, ImGuiCond_FirstUseEver);
     if (ImGui::TreeNode("Open Device"))
     {
         ImGuiExtensions::K4AComboBox("Device S/N",


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #

### Description of the changes:
-Building with "tool" feature fails. ImGui's SetNextTreeNodeOpen was previously deprecated and now has been removed. Call SetNextItemOpen instead.
see https://github.com/ocornut/imgui/blob/1362fc0c56d8742167379661a353d8342f7c4a86/imgui.h#L3131


<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [X] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [X] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [X] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [X] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [X] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [X] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

