### PR TITLE
Bugfix/image buffer release

### DIFF
--- a/src/python/k4a/setup.py
+++ b/src/python/k4a/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='k4a',
-    version='0.0.2',
+    version='0.0.3',
     author='Jonathan Santos',
     author_email='jonsanto@microsoft.com',
     description='Python interface to Azure Kinect API.',

--- a/src/python/k4a/src/k4a/_bindings/image.py
+++ b/src/python/k4a/src/k4a/_bindings/image.py
@@ -468,7 +468,7 @@ class Image:
     def __del__(self):
 
         # Deleting the _image_handle will release the image reference.
-        del self.image_handle
+        del self._image_handle
 
         del self.data
         del self.image_format
@@ -485,7 +485,7 @@ class Image:
     def __copy__(self):
 
         # Create a shallow copy.
-        new_image = Image(self.image_handle)
+        new_image = Image(self._image_handle)
         new_image._data = self._data.view()
         new_image._image_format = self._image_format
         new_image._size_bytes = self._size_bytes
@@ -559,11 +559,11 @@ class Image:
 
     # Define properties and get/set functions. ############### 
     @property
-    def image_handle(self):
+    def _image_handle(self):
         return self.__image_handle
 
-    @image_handle.deleter
-    def image_handle(self):
+    @_image_handle.deleter
+    def _image_handle(self):
 
         # Release the image before deleting.
         if isinstance(self._data, _np.ndarray):

--- a/src/python/k4a/src/k4a/_bindings/k4a.py
+++ b/src/python/k4a/src/k4a/_bindings/k4a.py
@@ -23,9 +23,30 @@ from .k4atypes import _DeviceHandle, _CaptureHandle, _ImageHandle, \
     _TransformationHandle, _Calibration, _Float2, _Float3, \
     _memory_allocate_cb, _memory_destroy_cb
 
-
-__all__ = []
-
+__all__ = ['k4a_image_create', 'k4a_image_create_from_buffer', 'k4a_set_debug_message_handler',
+           'k4a_image_release', 'k4a_image_get_buffer',
+           'k4a_image_reference', 'k4a_image_get_format',
+           'k4a_image_get_size', 'k4a_image_get_width_pixels',
+           'k4a_image_get_height_pixels', 'k4a_image_get_stride_bytes',
+           'k4a_image_get_device_timestamp_usec', 'k4a_image_set_device_timestamp_usec',
+           'k4a_image_get_system_timestamp_nsec', 'k4a_image_set_system_timestamp_nsec',
+           'k4a_image_get_exposure_usec', 'k4a_image_set_exposure_usec',
+           'k4a_image_get_white_balance', 'k4a_image_set_white_balance',
+           'k4a_image_get_iso_speed', 'k4a_image_set_iso_speed', 'k4a_calibration_get_from_raw',
+           'k4a_capture_create', 'k4a_capture_release', 'k4a_capture_reference',
+           'k4a_capture_get_color_image', 'k4a_capture_set_color_image',
+           'k4a_capture_get_depth_image', 'k4a_capture_set_depth_image',
+           'k4a_capture_get_ir_image', 'k4a_capture_set_ir_image',
+           'k4a_capture_get_temperature_c', 'k4a_capture_set_temperature_c',
+           'k4a_device_get_installed_count', 'k4a_device_open',
+           'k4a_device_get_serialnum', 'k4a_device_get_version',
+           'k4a_device_get_color_control_capabilities', 'k4a_device_close',
+           'k4a_device_get_imu_sample', 'k4a_device_get_color_control',
+           'k4a_device_start_cameras', 'k4a_device_stop_cameras',
+           'k4a_device_start_imu', 'k4a_device_stop_imu',
+           'k4a_device_set_color_control', 'k4a_device_get_raw_calibration',
+           'k4a_device_get_sync_jack', 'k4a_device_get_capture', 'k4a_device_get_calibration'
+           ]
 
 # Load the k4a.dll.
 try:
@@ -182,9 +203,7 @@ k4a_image_create_from_buffer = _k4a_lib.k4a_image_create_from_buffer
 k4a_image_create_from_buffer.restype = EStatus
 k4a_image_create_from_buffer.argtypes=(
     _ctypes.c_int, _ctypes.c_int, _ctypes.c_int, _ctypes.c_int, _ctypes.POINTER(_ctypes.c_uint8),
-    _ctypes.c_size_t, _memory_allocate_cb, _ctypes.c_void_p, _ctypes.POINTER(_ImageHandle))
-
-
+    _ctypes.c_size_t, _memory_destroy_cb, _ctypes.c_void_p, _ctypes.POINTER(_ImageHandle))
 
 #K4A_EXPORT uint8_t *k4a_image_get_buffer(k4a_image_t image_handle);
 k4a_image_get_buffer = _k4a_lib.k4a_image_get_buffer

--- a/src/python/k4a/tests/test_create_image.py
+++ b/src/python/k4a/tests/test_create_image.py
@@ -1,0 +1,59 @@
+"""
+test_create_image.py
+
+Tests for the creating Image objects using pre-allocated arrays.
+
+"""
+
+import numpy as np
+from numpy.random import default_rng
+import unittest
+
+import k4a
+
+
+class TestImages(unittest.TestCase):
+    """Test allocation of images.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        pass
+
+    def test_unit_create_from_ndarray(self):
+        # from inspect import currentframe, getframeinfo    # For debugging if needed
+
+        # Create an image with the default memory allocation and free
+        an_image = k4a.Image.create(k4a.EImageFormat.CUSTOM16, 640, 576, 640*2)
+        self.assertEqual(an_image.height_pixels, 576)
+        del an_image    # this will call the default image_release function
+
+        for index in range(5):
+            # We want a diverse source for the values, but also we want it to be deterministic
+            seed = 12345 + index
+            rng = default_rng(seed=seed)
+            two_channel_uint16 = rng.integers(0, high=65536, size=(576, 640), dtype=np.uint16)
+            # Uncomment these two lines to change the image buffer to show that the verification below works
+            # two_channel_uint16[0, 0] = (0x12 << 8) + 0x34
+            # two_channel_uint16[0, 1] = (0x56 << 8) + 0x78
+
+            custom_image = k4a.Image.create_from_ndarray(k4a.EImageFormat.CUSTOM16, two_channel_uint16)
+            two_channel_uint16 = rng.integers(0, high=32767, size=(576, 640), dtype=np.uint16)
+            # Ensure that the original array is no longer known locally, but the data is still available through custom_image
+            self.assertFalse(np.all(two_channel_uint16 == custom_image.data))
+            del two_channel_uint16
+
+            # Regenerate the values of the custom_image using the same seed for comparison
+            rng = default_rng(seed=seed)
+            verify_two_channel_uint16 = rng.integers(0, high=65536, size=(576, 640), dtype=np.uint16)
+
+            self.assertTrue(np.all(verify_two_channel_uint16 == custom_image.data))
+            del custom_image
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #1963

### Description of the changes:
- names of modules is corrected
- default values for the image size is taken from the given array
- the callback is correctly specified
- the reference count on the numpy array is incremented
- the declaration of `k4a_image_create_from_buffer` has been corrected

<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

