### PR TITLE
A button is added for convenience to the k4aviewer application

### DIFF
--- a/tools/k4aviewer/k4arecordingdockcontrol.cpp
+++ b/tools/k4aviewer/k4arecordingdockcontrol.cpp
@@ -158,6 +158,16 @@ K4ADockControlStatus K4ARecordingDockControl::Show()
     ImGui::Text("Subordinate delay (us): %d", m_subordinateDelayOffMasterUsec);
     ImGui::Text("Start timestamp offset: %d", m_startTimestampOffsetUsec);
     ImGui::Text("Recording Length (us):  %lu", m_recordingLengthUsec);
+    if (ImGui::Button("Copy to clipboard"))
+    {
+        std::stringstream sync_settings;
+        sync_settings << "Depth/color delay (us):" << m_depthDelayOffColorUsec << std::endl;
+        sync_settings << "Sync mode:" << m_wiredSyncModeLabel.c_str() << std::endl;
+        sync_settings << "Subordinate delay (us):" << m_subordinateDelayOffMasterUsec << std::endl;
+        sync_settings << "Start timestamp offset:" << m_startTimestampOffsetUsec << std::endl;
+        sync_settings << "Recording Length (us):" << m_recordingLengthUsec << std::endl;
+        ImGui::SetClipboardText(sync_settings.str().c_str());
+    }
     ImGui::Separator();
 
     ImGui::TextUnformatted("Device info");


### PR DESCRIPTION
A button is added for convenience to the k4aviewer application to make it easier to copy details about a recording.

<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #1969

### Description of the changes:
- A button is added to copy the Sync Settings info to the clipboard


<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [x] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [x] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [x] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [x] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

