### PR TITLE
Updating target framework to use net6.0

### DIFF
--- a/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
+++ b/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
+++ b/src/csharp/Tests/FunctionalTests/Microsoft.Azure.Kinect.Sensor.FunctionalTests.csproj
@@ -10,6 +10,7 @@
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <CodeAnalysisRuleSet>..\..\AzureKinectSensorSDK.ruleset</CodeAnalysisRuleSet>
     <OutputPath>$(BaseOutputPath)\$(AssemblyName)\</OutputPath>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
+++ b/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
+++ b/src/csharp/Tests/StubGenerator.UnitTests/Microsoft.Azure.Kinect.Sensor.Test.StubGenerator.UnitTests.csproj
@@ -12,6 +12,7 @@
     <OutputPath>$(BaseOutputPath)\$(AssemblyName)\</OutputPath>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Microsoft.Azure.Kinect.Sensor.snk</AssemblyOriginatorKeyFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
+++ b/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\k4a.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
+++ b/src/csharp/Tests/UnitTests/Microsoft.Azure.Kinect.Sensor.UnitTests.csproj
@@ -12,6 +12,7 @@
     <OutputPath>$(BaseOutputPath)\$(AssemblyName)\</OutputPath>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Microsoft.Azure.Kinect.Sensor.snk</AssemblyOriginatorKeyFile>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
<!-- 
     All pull requests should fix a Triage Approved issue. Put that issue # here:
     e.g. ## Fixes #300. 
-->
## Fixes #

### Description of the changes:
- Fixes errors in building C# tests by migrating to net6.0 (as prev. framework .netcore 3 is deprecated)


<!-- Please check off the appropriate boxes with [x] before submitting your pull request -->
### Before submitting a Pull Request:
- [ ] I reviewed [CONTRIBUTING.md](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/CONTRIBUTING.md)
- [ ] I [built my changes](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/building.md) locally
- [ ] I ran the [unit tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md)
- [ ] I ran the [functional tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device
- [ ] I ran the [performance tests](https://github.com/Microsoft/Azure-Kinect-Sensor-SDK/blob/develop/docs/testing.md) with a device

### I tested changes on: <!-- it's not required to have tested both, just indicate which one you tried -->
- [ ] Windows
- [ ] Linux


<!-- Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

